### PR TITLE
feat: add XIVAPI v2 client with reusable fetch-with-retry module

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,7 +31,8 @@
     "pino-loki": "^3.0.0",
     "reflect-metadata": "^0.2.2",
     "swagger-ui-express": "^5.0.1",
-    "tsyringe": "^4.8.0"
+    "tsyringe": "^4.8.0",
+    "typescript-retry-decorator": "^2.5.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/backend/src/lib/config/constants.ts
+++ b/backend/src/lib/config/constants.ts
@@ -94,3 +94,8 @@ export const REDACT = {
  * Same intent as rate-limit skips for docs, but we still record API traffic under `/v1/admin`.
  */
 export const METRICS_SKIP_ROUTE_PREFIXES = ['/v1/docs', '/v1/admin/docs', '/health'] as const;
+
+// ── XIVAPI (external game-data API) ────────────────────────────────
+export const XIVAPI_BASE_URL = 'https://v2.xivapi.com/api' as const;
+export const XIVAPI_TIMEOUT_MS = 5_000 as const;
+export const XIVAPI_RATE_LIMIT_PER_SECOND = 20 as const;

--- a/backend/src/lib/config/constants.ts
+++ b/backend/src/lib/config/constants.ts
@@ -95,7 +95,8 @@ export const REDACT = {
  */
 export const METRICS_SKIP_ROUTE_PREFIXES = ['/v1/docs', '/v1/admin/docs', '/health'] as const;
 
-// ── XIVAPI (external game-data API) ────────────────────────────────
 export const XIVAPI_BASE_URL = 'https://v2.xivapi.com/api' as const;
 export const XIVAPI_TIMEOUT_MS = 5_000 as const;
-export const XIVAPI_RATE_LIMIT_PER_SECOND = 20 as const;
+// Universalis API: https://docs.universalis.app/ — 25 req/s sustained, 50 req/s burst
+export const XIVAPI_RATE_LIMIT_PER_SECOND = 25 as const;
+export const XIVAPI_RATE_LIMIT_BURST = 50 as const;

--- a/backend/src/lib/http/fetchWithRetry.ts
+++ b/backend/src/lib/http/fetchWithRetry.ts
@@ -1,5 +1,8 @@
 /**
- * Reusable fetch-with-retry for outbound HTTP calls to external APIs.
+ * Base HTTP client with retry-on-429/5xx and exponential backoff.
+ *
+ * Subclasses extend `RetryingHttpClient`, pass retry settings to `super()`, and call
+ * `this.fetchJson(url, log)` or `this.fetchBlob(url, log)` for GET responses.
  *
  * Retry policy:
  *   - Exponential backoff: base * 2^attempt (default 1 s, 2 s, 4 s).
@@ -7,14 +10,20 @@
  *   - Non-retryable status codes (4xx other than 429) throw immediately.
  *   - Network errors and timeouts throw immediately (no retry).
  *
- * All failures throw `AppError.sourceUnavailable()` so they flow through
- * the error-handling middleware as 503 responses.
+ * The `@Retryable` decorator enforces the attempt budget; delays are applied in the
+ * runner (`backOff: 0` on the decorator) so `Retry-After` and backoff stay correct.
+ *
+ * Terminal failures throw `AppError.sourceUnavailable()` (503 + CDM code) for the
+ * global error middleware.
  */
 
 import type pino from 'pino';
+import { Retryable, BackOffPolicy } from 'typescript-retry-decorator';
 import { AppError } from '../errors/AppError.js';
+import { requestContext } from '../request/requestContext.js';
 
-export interface FetchWithRetryOptions {
+/** Configuration for `RetryingHttpClient` retry and timeout behavior. */
+export interface RetryingHttpClientConfig {
   /** Abort timeout per attempt (ms). */
   readonly timeoutMs: number;
   /** Maximum retry attempts after the initial request. */
@@ -24,11 +33,18 @@ export interface FetchWithRetryOptions {
   /** Human-readable source name for error messages (e.g. "XIVAPI", "Universalis"). */
   readonly sourceName: string;
   /** Optional hook called before each fetch attempt (e.g. token-bucket throttle). */
-  readonly beforeAttempt?: () => Promise<void>;
+  readonly beforeAttempt?: (ctx: BeforeAttemptContext) => Promise<void>;
 }
 
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_BACKOFF_BASE_MS = 1_000;
+
+/** Context passed to `beforeAttempt` so hooks (e.g. throttles) can attribute work. */
+export interface BeforeAttemptContext {
+  readonly url: string;
+  /** Incoming HTTP request id when `fetchJson` runs inside `requestContext` middleware. */
+  readonly requestId?: string;
+}
 
 function isRetryableStatus(status: number): boolean {
   return status === 429 || status >= 500;
@@ -58,34 +74,24 @@ function isTimeoutError(err: unknown): boolean {
   return false;
 }
 
-/**
- * Fetches `url` with timeout, retry on 429/5xx, and exponential backoff.
- * Returns the parsed JSON body on success.
- * Throws `AppError.sourceUnavailable()` on any terminal failure.
- */
-export async function fetchWithRetry(
-  url: string,
-  options: FetchWithRetryOptions,
-  log: pino.Logger
-): Promise<unknown> {
-  const {
-    timeoutMs,
-    maxRetries = DEFAULT_MAX_RETRIES,
-    backoffBaseMs = DEFAULT_BACKOFF_BASE_MS,
-    sourceName,
-    beforeAttempt,
-  } = options;
+class RetryableHttpStatusError extends Error {
+  constructor() {
+    super('retryable upstream status');
+    this.name = 'RetryableHttpStatusError';
+  }
+}
 
-  let lastStatus: number | undefined;
+export abstract class RetryingHttpClient {
+  protected constructor(protected readonly retryConfig: RetryingHttpClientConfig) {}
 
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    if (beforeAttempt) {
-      await beforeAttempt();
-    }
-
-    let res: Response;
+  /**
+   * Single HTTP GET with timeout (one attempt). Override in subclasses for POST,
+   * custom headers, or non-JSON pipelines while keeping `fetchJson` retry behavior.
+   */
+  protected async connect(url: string): Promise<Response> {
+    const { timeoutMs, sourceName } = this.retryConfig;
     try {
-      res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+      return await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
     } catch (err: unknown) {
       if (isTimeoutError(err)) {
         throw AppError.sourceUnavailable(`${sourceName} request timed out after ${timeoutMs}ms`);
@@ -94,28 +100,139 @@ export async function fetchWithRetry(
         err instanceof Error ? err.message : `${sourceName} network error`
       );
     }
-
-    if (res.ok) {
-      return (await res.json()) as unknown;
-    }
-
-    lastStatus = res.status;
-
-    if (!isRetryableStatus(res.status)) {
-      throw AppError.sourceUnavailable(`${sourceName} responded with ${res.status}`);
-    }
-
-    if (attempt < maxRetries) {
-      const delay = computeRetryDelay(attempt, res.headers.get('Retry-After'), backoffBaseMs);
-      log.warn(
-        { status: res.status, attempt, delay, url },
-        `${sourceName} retryable error; backing off`
-      );
-      await sleep(delay);
-    }
   }
 
-  throw AppError.sourceUnavailable(
-    `${sourceName} responded with ${lastStatus} after ${maxRetries} retries`
-  );
+  /**
+   * GET JSON with retries on 429/5xx. The `@Retryable` runner invokes `connect` per attempt.
+   */
+  fetchJson(url: string, log: pino.Logger): Promise<unknown> {
+    const {
+      maxRetries = DEFAULT_MAX_RETRIES,
+      backoffBaseMs = DEFAULT_BACKOFF_BASE_MS,
+      sourceName,
+      beforeAttempt,
+    } = this.retryConfig;
+
+    const runConnect = (): Promise<Response> => this.connect(url);
+
+    class JsonRetryRunner {
+      private attempt = 0;
+
+      @Retryable({
+        maxAttempts: maxRetries,
+        backOff: 0,
+        backOffPolicy: BackOffPolicy.FixedBackOffPolicy,
+        value: [RetryableHttpStatusError],
+        useOriginalError: true,
+        useConsoleLogger: false,
+      })
+      async run(): Promise<unknown> {
+        if (beforeAttempt) {
+          const store = requestContext.get();
+          await beforeAttempt({
+            url,
+            ...(store?.requestId !== undefined ? { requestId: store.requestId } : {}),
+          });
+        }
+
+        const res = await runConnect();
+
+        if (res.ok) {
+          return (await res.json()) as unknown;
+        }
+
+        if (!isRetryableStatus(res.status)) {
+          throw AppError.sourceUnavailable(`${sourceName} responded with ${res.status}`);
+        }
+
+        if (this.attempt >= maxRetries) {
+          throw AppError.sourceUnavailable(
+            `${sourceName} responded with ${res.status} after ${maxRetries} retries`
+          );
+        }
+
+        const delay = computeRetryDelay(
+          this.attempt,
+          res.headers.get('Retry-After'),
+          backoffBaseMs
+        );
+        log.warn(
+          { status: res.status, attempt: this.attempt, delay, url },
+          `${sourceName} retryable error; backing off`
+        );
+        this.attempt += 1;
+        await sleep(delay);
+        throw new RetryableHttpStatusError();
+      }
+    }
+
+    return new JsonRetryRunner().run();
+  }
+
+  /**
+   * GET binary body with retries on 429/5xx. Same attempt budget and backoff as `fetchJson`.
+   */
+  fetchBlob(url: string, log: pino.Logger): Promise<Blob> {
+    const {
+      maxRetries = DEFAULT_MAX_RETRIES,
+      backoffBaseMs = DEFAULT_BACKOFF_BASE_MS,
+      sourceName,
+      beforeAttempt,
+    } = this.retryConfig;
+
+    const runConnect = (): Promise<Response> => this.connect(url);
+
+    class BlobRetryRunner {
+      private attempt = 0;
+
+      @Retryable({
+        maxAttempts: maxRetries,
+        backOff: 0,
+        backOffPolicy: BackOffPolicy.FixedBackOffPolicy,
+        value: [RetryableHttpStatusError],
+        useOriginalError: true,
+        useConsoleLogger: false,
+      })
+      async run(): Promise<Blob> {
+        if (beforeAttempt) {
+          const store = requestContext.get();
+          await beforeAttempt({
+            url,
+            ...(store?.requestId !== undefined ? { requestId: store.requestId } : {}),
+          });
+        }
+
+        const res = await runConnect();
+
+        if (res.ok) {
+          return res.blob();
+        }
+
+        if (!isRetryableStatus(res.status)) {
+          throw AppError.sourceUnavailable(`${sourceName} responded with ${res.status}`);
+        }
+
+        if (this.attempt >= maxRetries) {
+          throw AppError.sourceUnavailable(
+            `${sourceName} responded with ${res.status} after ${maxRetries} retries`
+          );
+        }
+
+        const delay = computeRetryDelay(
+          this.attempt,
+          res.headers.get('Retry-After'),
+          backoffBaseMs
+        );
+        log.warn(
+          { status: res.status, attempt: this.attempt, delay, url },
+          `${sourceName} retryable error; backing off`
+        );
+        this.attempt += 1;
+        await sleep(delay);
+        throw new RetryableHttpStatusError();
+      }
+    }
+
+    return new BlobRetryRunner().run();
+  }
 }

--- a/backend/src/lib/http/fetchWithRetry.ts
+++ b/backend/src/lib/http/fetchWithRetry.ts
@@ -1,0 +1,121 @@
+/**
+ * Reusable fetch-with-retry for outbound HTTP calls to external APIs.
+ *
+ * Retry policy:
+ *   - Exponential backoff: base * 2^attempt (default 1 s, 2 s, 4 s).
+ *   - A 429 `Retry-After` header (seconds) overrides the computed delay.
+ *   - Non-retryable status codes (4xx other than 429) throw immediately.
+ *   - Network errors and timeouts throw immediately (no retry).
+ *
+ * All failures throw `AppError.sourceUnavailable()` so they flow through
+ * the error-handling middleware as 503 responses.
+ */
+
+import type pino from 'pino';
+import { AppError } from '../errors/AppError.js';
+
+export interface FetchWithRetryOptions {
+  /** Abort timeout per attempt (ms). */
+  readonly timeoutMs: number;
+  /** Maximum retry attempts after the initial request. */
+  readonly maxRetries?: number;
+  /** Base delay for exponential backoff (ms). Actual delay = base * 2^attempt. */
+  readonly backoffBaseMs?: number;
+  /** Human-readable source name for error messages (e.g. "XIVAPI", "Universalis"). */
+  readonly sourceName: string;
+  /** Optional hook called before each fetch attempt (e.g. token-bucket throttle). */
+  readonly beforeAttempt?: () => Promise<void>;
+}
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BACKOFF_BASE_MS = 1_000;
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function computeRetryDelay(
+  attempt: number,
+  retryAfterHeader: string | null,
+  backoffBaseMs: number
+): number {
+  if (retryAfterHeader !== null) {
+    const seconds = Number(retryAfterHeader);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return seconds * 1_000;
+    }
+  }
+  return backoffBaseMs * 2 ** attempt;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTimeoutError(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === 'TimeoutError') return true;
+  if (err instanceof Error && err.name === 'AbortError') return true;
+  return false;
+}
+
+/**
+ * Fetches `url` with timeout, retry on 429/5xx, and exponential backoff.
+ * Returns the parsed JSON body on success.
+ * Throws `AppError.sourceUnavailable()` on any terminal failure.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: FetchWithRetryOptions,
+  log: pino.Logger
+): Promise<unknown> {
+  const {
+    timeoutMs,
+    maxRetries = DEFAULT_MAX_RETRIES,
+    backoffBaseMs = DEFAULT_BACKOFF_BASE_MS,
+    sourceName,
+    beforeAttempt,
+  } = options;
+
+  let lastStatus: number | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (beforeAttempt) {
+      await beforeAttempt();
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    } catch (err: unknown) {
+      if (isTimeoutError(err)) {
+        throw AppError.sourceUnavailable(`${sourceName} request timed out after ${timeoutMs}ms`);
+      }
+      throw AppError.sourceUnavailable(
+        err instanceof Error ? err.message : `${sourceName} network error`
+      );
+    }
+
+    if (res.ok) {
+      return (await res.json()) as unknown;
+    }
+
+    lastStatus = res.status;
+
+    if (!isRetryableStatus(res.status)) {
+      throw AppError.sourceUnavailable(`${sourceName} responded with ${res.status}`);
+    }
+
+    if (attempt < maxRetries) {
+      const delay = computeRetryDelay(attempt, res.headers.get('Retry-After'), backoffBaseMs);
+      log.warn(
+        { status: res.status, attempt, delay, url },
+        `${sourceName} retryable error; backing off`
+      );
+      await sleep(delay);
+    }
+  }
+
+  throw AppError.sourceUnavailable(
+    `${sourceName} responded with ${lastStatus} after ${maxRetries} retries`
+  );
+}

--- a/backend/src/lib/xivapi/XIVApiClient.ts
+++ b/backend/src/lib/xivapi/XIVApiClient.ts
@@ -1,0 +1,78 @@
+/**
+ * XIVAPI v2 (boilmaster) HTTP client factory.
+ *
+ * Provides a thin wrapper around `fetchWithRetry` for querying v2.xivapi.com game-data endpoints.
+ * All outbound requests are throttled by a token-bucket rate limiter and guarded by a timeout.
+ *
+ * Retry, backoff, and error handling are delegated to the shared `fetchWithRetry` module;
+ * this file only owns URL construction and parameter mapping.
+ *
+ * XIVAPI v2 is open and requires no authentication.
+ */
+
+import type pino from 'pino';
+import { fetchWithRetry } from '../http/fetchWithRetry.js';
+import type { TokenBucket } from './throttle.js';
+import type {
+  XivApiClient,
+  XivApiRowParams,
+  XivApiRowResponse,
+  XivApiSearchParams,
+  XivApiSearchResult,
+} from './types.js';
+
+/** Configuration consumed by the client factory. */
+export interface XivApiClientConfig {
+  readonly baseUrl: string;
+  readonly timeoutMs: number;
+}
+
+const SOURCE_NAME = 'XIVAPI';
+
+/** Creates an `XivApiClient` backed by native `fetch`, a token-bucket throttle, and Pino logger. */
+export function createXivApiClient(
+  config: XivApiClientConfig,
+  throttle: TokenBucket,
+  log: pino.Logger
+): XivApiClient {
+  const retryOptions = {
+    timeoutMs: config.timeoutMs,
+    sourceName: SOURCE_NAME,
+    beforeAttempt: () => throttle.consume(),
+  };
+
+  function buildUrl(path: string): URL {
+    const base = config.baseUrl.endsWith('/') ? config.baseUrl : config.baseUrl + '/';
+    return new URL(path, base);
+  }
+
+  function setOptionalParam(url: URL, key: string, value: string | number | undefined): void {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return {
+    async search(params: XivApiSearchParams): Promise<XivApiSearchResult> {
+      const url = buildUrl('search');
+      setOptionalParam(url, 'query', params.query);
+      setOptionalParam(url, 'sheets', params.sheets);
+      setOptionalParam(url, 'cursor', params.cursor);
+      setOptionalParam(url, 'limit', params.limit);
+      setOptionalParam(url, 'language', params.language);
+      setOptionalParam(url, 'fields', params.fields);
+      setOptionalParam(url, 'transient', params.transient);
+
+      return (await fetchWithRetry(url.toString(), retryOptions, log)) as XivApiSearchResult;
+    },
+
+    async getRow(sheet: string, row: number, params?: XivApiRowParams): Promise<XivApiRowResponse> {
+      const url = buildUrl(`sheet/${encodeURIComponent(sheet)}/${row}`);
+      setOptionalParam(url, 'language', params?.language);
+      setOptionalParam(url, 'fields', params?.fields);
+      setOptionalParam(url, 'transient', params?.transient);
+
+      return (await fetchWithRetry(url.toString(), retryOptions, log)) as XivApiRowResponse;
+    },
+  };
+}

--- a/backend/src/lib/xivapi/XIVApiClient.ts
+++ b/backend/src/lib/xivapi/XIVApiClient.ts
@@ -1,24 +1,33 @@
 /**
  * XIVAPI v2 (boilmaster) HTTP client factory.
  *
- * Provides a thin wrapper around `fetchWithRetry` for querying v2.xivapi.com game-data endpoints.
+ * Provides a thin wrapper around `RetryingHttpClient` for querying v2.xivapi.com game-data endpoints.
  * All outbound requests are throttled by a token-bucket rate limiter and guarded by a timeout.
  *
- * Retry, backoff, and error handling are delegated to the shared `fetchWithRetry` module;
- * this file only owns URL construction and parameter mapping.
+ * Retry, backoff, and error handling are delegated to the shared `RetryingHttpClient` base;
+ * this module only owns URL construction and parameter mapping.
  *
  * XIVAPI v2 is open and requires no authentication.
  */
 
 import type pino from 'pino';
-import { fetchWithRetry } from '../http/fetchWithRetry.js';
+import { RetryingHttpClient } from '../http/fetchWithRetry.js';
 import type { TokenBucket } from './throttle.js';
 import type {
+  XivApiAssetBody,
+  XivApiAssetParams,
   XivApiClient,
+  XivApiListSheetsParams,
+  XivApiListSheetsResponse,
+  XivApiMapPathParams,
   XivApiRowParams,
   XivApiRowResponse,
   XivApiSearchParams,
   XivApiSearchResult,
+  XivApiSheetResponse,
+  XivApiSheetRowsParams,
+  XivApiVersionQueryParams,
+  XivApiVersionsResponse,
 } from './types.js';
 
 /** Configuration consumed by the client factory. */
@@ -29,50 +38,116 @@ export interface XivApiClientConfig {
 
 const SOURCE_NAME = 'XIVAPI';
 
+export class XivApiHttpClient extends RetryingHttpClient implements XivApiClient {
+  private readonly log: pino.Logger;
+  private readonly baseUrl: string;
+
+  constructor(config: XivApiClientConfig, throttle: TokenBucket, log: pino.Logger) {
+    super({
+      timeoutMs: config.timeoutMs,
+      sourceName: SOURCE_NAME,
+      beforeAttempt: (ctx) =>
+        throttle.consume({
+          url: ctx.url,
+          ...(ctx.requestId !== undefined ? { requestId: ctx.requestId } : {}),
+        }),
+    });
+    this.baseUrl = config.baseUrl;
+    this.log = log;
+  }
+
+  private buildUrl(path: string): URL {
+    const base = this.baseUrl.endsWith('/') ? this.baseUrl : this.baseUrl + '/';
+    return new URL(path, base);
+  }
+
+  private setOptionalParam(url: URL, key: string, value: string | number | undefined): void {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  async getAsset(params: XivApiAssetParams): Promise<XivApiAssetBody> {
+    const url = this.buildUrl('asset');
+    url.searchParams.set('path', params.path);
+    url.searchParams.set('format', params.format);
+    this.setOptionalParam(url, 'version', params.version);
+    return this.fetchBlob(url.toString(), this.log);
+  }
+
+  async getMapAsset(
+    path: XivApiMapPathParams,
+    params?: XivApiVersionQueryParams
+  ): Promise<XivApiAssetBody> {
+    const url = this.buildUrl(
+      `asset/map/${encodeURIComponent(path.territory)}/${encodeURIComponent(path.index)}`
+    );
+    this.setOptionalParam(url, 'version', params?.version);
+    return this.fetchBlob(url.toString(), this.log);
+  }
+
+  async search(params: XivApiSearchParams): Promise<XivApiSearchResult> {
+    const url = this.buildUrl('search');
+    this.setOptionalParam(url, 'version', params.version);
+    this.setOptionalParam(url, 'query', params.query);
+    this.setOptionalParam(url, 'sheets', params.sheets);
+    this.setOptionalParam(url, 'cursor', params.cursor);
+    this.setOptionalParam(url, 'limit', params.limit);
+    this.setOptionalParam(url, 'language', params.language);
+    this.setOptionalParam(url, 'schema', params.schema);
+    this.setOptionalParam(url, 'fields', params.fields);
+    this.setOptionalParam(url, 'transient', params.transient);
+
+    return (await this.fetchJson(url.toString(), this.log)) as XivApiSearchResult;
+  }
+
+  async listSheets(params?: XivApiListSheetsParams): Promise<XivApiListSheetsResponse> {
+    const url = this.buildUrl('sheet');
+    this.setOptionalParam(url, 'version', params?.version);
+    return (await this.fetchJson(url.toString(), this.log)) as XivApiListSheetsResponse;
+  }
+
+  async listSheetRows(sheet: string, params?: XivApiSheetRowsParams): Promise<XivApiSheetResponse> {
+    const url = this.buildUrl(`sheet/${encodeURIComponent(sheet)}`);
+    this.setOptionalParam(url, 'version', params?.version);
+    this.setOptionalParam(url, 'rows', params?.rows);
+    this.setOptionalParam(url, 'limit', params?.limit);
+    if (params?.after !== undefined && params.after !== null) {
+      url.searchParams.set('after', params.after);
+    }
+    this.setOptionalParam(url, 'language', params?.language);
+    this.setOptionalParam(url, 'schema', params?.schema);
+    this.setOptionalParam(url, 'fields', params?.fields);
+    this.setOptionalParam(url, 'transient', params?.transient);
+    return (await this.fetchJson(url.toString(), this.log)) as XivApiSheetResponse;
+  }
+
+  async getRow(
+    sheet: string,
+    row: number | string,
+    params?: XivApiRowParams
+  ): Promise<XivApiRowResponse> {
+    const rowSeg = typeof row === 'number' ? String(row) : row;
+    const url = this.buildUrl(`sheet/${encodeURIComponent(sheet)}/${encodeURIComponent(rowSeg)}`);
+    this.setOptionalParam(url, 'language', params?.language);
+    this.setOptionalParam(url, 'schema', params?.schema);
+    this.setOptionalParam(url, 'fields', params?.fields);
+    this.setOptionalParam(url, 'transient', params?.transient);
+
+    return (await this.fetchJson(url.toString(), this.log)) as XivApiRowResponse;
+  }
+
+  async listVersions(): Promise<XivApiVersionsResponse> {
+    const url = this.buildUrl('version');
+    return (await this.fetchJson(url.toString(), this.log)) as XivApiVersionsResponse;
+  }
+}
+
 /** Creates an `XivApiClient` backed by native `fetch`, a token-bucket throttle, and Pino logger. */
 export function createXivApiClient(
   config: XivApiClientConfig,
   throttle: TokenBucket,
   log: pino.Logger
 ): XivApiClient {
-  const retryOptions = {
-    timeoutMs: config.timeoutMs,
-    sourceName: SOURCE_NAME,
-    beforeAttempt: () => throttle.consume(),
-  };
-
-  function buildUrl(path: string): URL {
-    const base = config.baseUrl.endsWith('/') ? config.baseUrl : config.baseUrl + '/';
-    return new URL(path, base);
-  }
-
-  function setOptionalParam(url: URL, key: string, value: string | number | undefined): void {
-    if (value !== undefined) {
-      url.searchParams.set(key, String(value));
-    }
-  }
-
-  return {
-    async search(params: XivApiSearchParams): Promise<XivApiSearchResult> {
-      const url = buildUrl('search');
-      setOptionalParam(url, 'query', params.query);
-      setOptionalParam(url, 'sheets', params.sheets);
-      setOptionalParam(url, 'cursor', params.cursor);
-      setOptionalParam(url, 'limit', params.limit);
-      setOptionalParam(url, 'language', params.language);
-      setOptionalParam(url, 'fields', params.fields);
-      setOptionalParam(url, 'transient', params.transient);
-
-      return (await fetchWithRetry(url.toString(), retryOptions, log)) as XivApiSearchResult;
-    },
-
-    async getRow(sheet: string, row: number, params?: XivApiRowParams): Promise<XivApiRowResponse> {
-      const url = buildUrl(`sheet/${encodeURIComponent(sheet)}/${row}`);
-      setOptionalParam(url, 'language', params?.language);
-      setOptionalParam(url, 'fields', params?.fields);
-      setOptionalParam(url, 'transient', params?.transient);
-
-      return (await fetchWithRetry(url.toString(), retryOptions, log)) as XivApiRowResponse;
-    },
-  };
+  return new XivApiHttpClient(config, throttle, log);
 }

--- a/backend/src/lib/xivapi/throttle.ts
+++ b/backend/src/lib/xivapi/throttle.ts
@@ -1,0 +1,50 @@
+/**
+ * In-process token-bucket rate limiter for outbound XIVAPI requests.
+ *
+ * Ensures a single backend instance stays under XIVAPI's per-IP rate cap.
+ * The bucket refills continuously based on elapsed wall-clock time; when empty,
+ * `consume()` returns a promise that resolves once a token becomes available.
+ *
+ * Multi-instance shared limiting (e.g. Redis) is out of scope for MVP.
+ */
+
+export interface TokenBucket {
+  /** Waits until a token is available, then consumes one. */
+  consume(): Promise<void>;
+}
+
+/**
+ * Creates a token bucket that allows `tokensPerSecond` requests per second.
+ * Burst capacity equals one full second of tokens.
+ */
+export function createTokenBucket(tokensPerSecond: number): TokenBucket {
+  let tokens = tokensPerSecond;
+  let lastRefill = Date.now();
+
+  function refill(): void {
+    const now = Date.now();
+    const elapsed = (now - lastRefill) / 1_000;
+    tokens = Math.min(tokensPerSecond, tokens + elapsed * tokensPerSecond);
+    lastRefill = now;
+  }
+
+  function consume(): Promise<void> {
+    refill();
+
+    if (tokens >= 1) {
+      tokens -= 1;
+      return Promise.resolve();
+    }
+
+    const waitMs = ((1 - tokens) / tokensPerSecond) * 1_000;
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        refill();
+        tokens = Math.max(0, tokens - 1);
+        resolve();
+      }, waitMs);
+    });
+  }
+
+  return { consume };
+}

--- a/backend/src/lib/xivapi/throttle.ts
+++ b/backend/src/lib/xivapi/throttle.ts
@@ -1,34 +1,26 @@
-/**
- * In-process token-bucket rate limiter for outbound XIVAPI requests.
- *
- * Ensures a single backend instance stays under XIVAPI's per-IP rate cap.
- * The bucket refills continuously based on elapsed wall-clock time; when empty,
- * `consume()` returns a promise that resolves once a token becomes available.
- *
- * Multi-instance shared limiting (e.g. Redis) is out of scope for MVP.
- */
+import type pino from 'pino';
 
 export interface TokenBucket {
-  /** Waits until a token is available, then consumes one. */
-  consume(): Promise<void>;
+  /** Optional structured fields for logs (e.g. `url` from the outbound HTTP request). */
+  consume(meta?: Readonly<Record<string, unknown>>): Promise<void>;
 }
 
-/**
- * Creates a token bucket that allows `tokensPerSecond` requests per second.
- * Burst capacity equals one full second of tokens.
- */
-export function createTokenBucket(tokensPerSecond: number): TokenBucket {
-  let tokens = tokensPerSecond;
+export function createTokenBucket(
+  ratePerSecond: number,
+  burstCapacity: number = ratePerSecond,
+  log?: pino.Logger
+): TokenBucket {
+  let tokens = burstCapacity;
   let lastRefill = Date.now();
 
   function refill(): void {
     const now = Date.now();
     const elapsed = (now - lastRefill) / 1_000;
-    tokens = Math.min(tokensPerSecond, tokens + elapsed * tokensPerSecond);
+    tokens = Math.min(burstCapacity, tokens + elapsed * ratePerSecond);
     lastRefill = now;
   }
 
-  function consume(): Promise<void> {
+  function consume(meta?: Readonly<Record<string, unknown>>): Promise<void> {
     refill();
 
     if (tokens >= 1) {
@@ -36,7 +28,19 @@ export function createTokenBucket(tokensPerSecond: number): TokenBucket {
       return Promise.resolve();
     }
 
-    const waitMs = ((1 - tokens) / tokensPerSecond) * 1_000;
+    const waitMs = ((1 - tokens) / ratePerSecond) * 1_000;
+    if (log) {
+      log.warn(
+        {
+          waitMs,
+          tokens,
+          ratePerSecond,
+          burstCapacity,
+          ...meta,
+        },
+        'Token bucket empty; awaiting token refill'
+      );
+    }
     return new Promise<void>((resolve) => {
       setTimeout(() => {
         refill();

--- a/backend/src/lib/xivapi/types.ts
+++ b/backend/src/lib/xivapi/types.ts
@@ -1,80 +1,239 @@
 /**
- * XIVAPI v2 (boilmaster) domain types and client interface.
- *
- * XIVAPI is an open, free REST API for FFXIV game data (items, quests, actions, etc.).
- * V2 docs: https://v2.xivapi.com/api/docs
- * Response types here are intentionally minimal (MVP); extend as endpoints are consumed.
+ * Types aligned with the boilmaster / XIVAPI v2 OpenAPI document (`api-1.json`).
+ * Names use an `XivApi` prefix; JSDoc notes the matching `components/schemas/*` entry where applicable.
  */
 
-/** XIVAPI-supported language codes (TR-7: en, ja, de, fr). */
+/** OpenAPI: `SchemaLanguage` */
 export const XivApiLanguage = {
+  None: 'none',
   En: 'en',
   Ja: 'ja',
   De: 'de',
   Fr: 'fr',
+  Chs: 'chs',
+  Cht: 'cht',
+  Kr: 'kr',
 } as const;
 
 export type XivApiLanguage = (typeof XivApiLanguage)[keyof typeof XivApiLanguage];
 
-/** Error envelope returned by all v2 endpoints on non-200 responses. */
+/** OpenAPI: `SchemaFormat` */
+export const XivApiSchemaFormat = {
+  Jpg: 'jpg',
+  Png: 'png',
+  Webp: 'webp',
+} as const;
+
+export type XivApiSchemaFormat = (typeof XivApiSchemaFormat)[keyof typeof XivApiSchemaFormat];
+
+/** OpenAPI: `StatusCode` (HTTP status as uint16). */
+export type XivApiStatusCode = number;
+
+/** OpenAPI: `ErrorResponse` */
 export interface XivApiErrorResponse {
-  readonly code: number;
+  readonly code: XivApiStatusCode;
   readonly message: string;
 }
 
-/** Parameters for `GET /search`. */
-export interface XivApiSearchParams {
-  /** Search query string (v2 query syntax). */
-  readonly query?: string;
-  /** Comma-separated sheet names to search (e.g. "Quest,Item"). */
-  readonly sheets?: string;
-  /** Cursor UUID for pagination (returned as `next` in a prior response). */
-  readonly cursor?: string;
-  readonly limit?: number;
-  readonly language?: XivApiLanguage;
-  /** Field filter for row data (dot notation, e.g. "Name,Icon"). */
-  readonly fields?: string;
-  /** Field filter for transient row data. */
-  readonly transient?: string;
+/**
+ * OpenAPI: `QueryString` — search clause grammar (see spec for operations and value types).
+ */
+export type XivApiQueryString = string;
+
+/**
+ * OpenAPI: `FilterString` — comma-separated field paths with optional `@decorator(...)` segments.
+ */
+export type XivApiFilterString = string;
+
+/** OpenAPI: `SchemaSpecifier` — pattern `^.+(@.+)?$` */
+export type XivApiSchemaSpecifier = string;
+
+/** OpenAPI: `RowSpecifier` — pattern `^\d+(:\d+)?$` (main row, optional `:subrow`). */
+export type XivApiRowSpecifier = string;
+
+/** OpenAPI: `ValueString` — arbitrary JSON object of row field values. */
+export type XivApiValueRecord = Record<string, unknown>;
+
+// ── Version query (shared) ────────────────────────────────────────────────
+
+/** OpenAPI: `VersionQueryParams` */
+export interface XivApiVersionQueryParams {
+  readonly version?: string;
 }
 
-/** A single search hit from `GET /search`. */
+// ── GET /asset ───────────────────────────────────────────────────────────
+
+/** OpenAPI: `AssetQuery` */
+export interface XivApiAssetQuery {
+  readonly path: string;
+  readonly format: XivApiSchemaFormat;
+}
+
+/** OpenAPI: `AssetQuery` & `version` query parameter on `GET /asset`. */
+export interface XivApiAssetParams extends XivApiAssetQuery, XivApiVersionQueryParams {}
+
+/** Successful asset responses are binary image bodies (`image/jpeg` | `image/png` | `image/webp`). */
+export type XivApiAssetBody = Blob;
+
+// ── GET /asset/map/{territory}/{index} ─────────────────────────────────────
+
+/** OpenAPI: `MapPath` */
+export interface XivApiMapPathParams {
+  readonly territory: string;
+  readonly index: string;
+}
+
+// ── GET /search ────────────────────────────────────────────────────────────
+
+/** OpenAPI: `SearchQuery` */
+export interface XivApiSearchQueryParams {
+  readonly query?: XivApiQueryString;
+  readonly sheets?: string;
+  readonly cursor?: string;
+  readonly limit?: number;
+}
+
+/** OpenAPI: `RowReaderQuery` */
+export interface XivApiRowReaderQueryParams {
+  readonly language?: XivApiLanguage;
+  readonly schema?: XivApiSchemaSpecifier;
+  readonly fields?: XivApiFilterString;
+  readonly transient?: XivApiFilterString;
+}
+
+/**
+ * OpenAPI: `/search` query — `VersionQueryParams` & `SearchQuery` & `RowReaderQuery`.
+ */
+export interface XivApiSearchParams
+  extends XivApiVersionQueryParams, XivApiSearchQueryParams, XivApiRowReaderQueryParams {}
+
+/** OpenAPI: `SearchResult` */
 export interface XivApiSearchResultEntry {
   readonly score: number;
   readonly sheet: string;
   readonly row_id: number;
-  readonly subrow_id?: number;
-  readonly fields: Record<string, unknown>;
-  readonly transient?: Record<string, unknown>;
+  readonly subrow_id?: number | null;
+  readonly fields: XivApiValueRecord;
+  readonly transient?: XivApiValueRecord | null;
 }
 
-/** Response envelope from `GET /search`. */
+/** OpenAPI: `SearchResult` (alias). */
+export type XivApiSearchResultItem = XivApiSearchResultEntry;
+
+/** OpenAPI: `SearchResponse` */
 export interface XivApiSearchResult {
-  readonly next?: string;
+  readonly next?: string | null;
   readonly results: readonly XivApiSearchResultEntry[];
   readonly schema: string;
   readonly version: string;
 }
 
-/** Optional parameters for `GET /sheet/{sheet}/{row}`. */
-export interface XivApiRowParams {
-  readonly language?: XivApiLanguage;
-  readonly fields?: string;
-  readonly transient?: string;
+/** OpenAPI: `SearchResponse` (alias for callers who prefer the spec name). */
+export type XivApiSearchResponse = XivApiSearchResult;
+
+// ── GET /sheet ─────────────────────────────────────────────────────────────
+
+/** OpenAPI: `/sheet` query — only `version`. */
+export type XivApiListSheetsParams = XivApiVersionQueryParams;
+
+/** OpenAPI: `SheetMetadata` */
+export interface XivApiSheetMetadata {
+  readonly name: string;
 }
 
-/** Response from `GET /sheet/{sheet}/{row}`. */
-export interface XivApiRowResponse {
+/** OpenAPI: `ListResponse` */
+export interface XivApiListSheetsResponse {
+  readonly sheets: readonly XivApiSheetMetadata[];
+}
+
+/** OpenAPI: `ListResponse` (alias). */
+export type XivApiListResponse = XivApiListSheetsResponse;
+
+// ── GET /sheet/{sheet} ─────────────────────────────────────────────────────
+
+/** OpenAPI: `SheetPath` */
+export interface XivApiSheetPathParams {
+  readonly sheet: string;
+}
+
+/** OpenAPI: `SheetQuery` */
+export interface XivApiSheetQueryParams {
+  readonly rows?: string;
+  readonly limit?: number;
+  readonly after?: XivApiRowSpecifier | null;
+}
+
+/**
+ * OpenAPI: `/sheet/{sheet}` query — `VersionQueryParams` & `SheetQuery` & `RowReaderQuery`.
+ */
+export interface XivApiSheetRowsParams
+  extends XivApiVersionQueryParams, XivApiSheetQueryParams, XivApiRowReaderQueryParams {}
+
+/** OpenAPI: `RowResult` */
+export interface XivApiRowResult {
   readonly row_id: number;
-  readonly subrow_id?: number;
-  readonly fields: Record<string, unknown>;
-  readonly transient?: Record<string, unknown>;
+  readonly subrow_id?: number | null;
+  readonly fields: XivApiValueRecord;
+  readonly transient?: XivApiValueRecord | null;
+}
+
+/** OpenAPI: `SheetResponse` */
+export interface XivApiSheetResponse {
+  readonly rows: readonly XivApiRowResult[];
   readonly schema: string;
   readonly version: string;
 }
 
-/** Public contract for the XIVAPI v2 HTTP client. */
+// ── GET /sheet/{sheet}/{row} ───────────────────────────────────────────────
+
+/** OpenAPI: `RowPath` */
+export interface XivApiRowPathParams {
+  readonly sheet: string;
+  readonly row: XivApiRowSpecifier;
+}
+
+/** OpenAPI: `RowReaderQuery` (same shape as query params on `/sheet/{sheet}/{row}`). */
+export type XivApiRowParams = XivApiRowReaderQueryParams;
+
+/** OpenAPI: `RowResponse` */
+export interface XivApiRowResponse {
+  readonly schema: string;
+  readonly version: string;
+  readonly row_id: number;
+  readonly subrow_id?: number | null;
+  readonly fields: XivApiValueRecord;
+  readonly transient?: XivApiValueRecord | null;
+}
+
+// ── GET /version ───────────────────────────────────────────────────────────
+
+/** OpenAPI: `VersionMetadata` */
+export interface XivApiVersionMetadata {
+  readonly key: string;
+  readonly names: readonly string[];
+}
+
+/** OpenAPI: `VersionsResponse` */
+export interface XivApiVersionsResponse {
+  readonly versions: readonly XivApiVersionMetadata[];
+}
+
+// ── Client surface ─────────────────────────────────────────────────────────
+
 export interface XivApiClient {
+  getAsset(params: XivApiAssetParams): Promise<XivApiAssetBody>;
+  getMapAsset(
+    path: XivApiMapPathParams,
+    params?: XivApiVersionQueryParams
+  ): Promise<XivApiAssetBody>;
   search(params: XivApiSearchParams): Promise<XivApiSearchResult>;
-  getRow(sheet: string, row: number, params?: XivApiRowParams): Promise<XivApiRowResponse>;
+  listSheets(params?: XivApiListSheetsParams): Promise<XivApiListSheetsResponse>;
+  listSheetRows(sheet: string, params?: XivApiSheetRowsParams): Promise<XivApiSheetResponse>;
+  /** `row` may be a main id or a `main:subrow` specifier per `RowSpecifier`. */
+  getRow(
+    sheet: string,
+    row: number | XivApiRowSpecifier,
+    params?: XivApiRowParams
+  ): Promise<XivApiRowResponse>;
+  listVersions(): Promise<XivApiVersionsResponse>;
 }

--- a/backend/src/lib/xivapi/types.ts
+++ b/backend/src/lib/xivapi/types.ts
@@ -1,0 +1,80 @@
+/**
+ * XIVAPI v2 (boilmaster) domain types and client interface.
+ *
+ * XIVAPI is an open, free REST API for FFXIV game data (items, quests, actions, etc.).
+ * V2 docs: https://v2.xivapi.com/api/docs
+ * Response types here are intentionally minimal (MVP); extend as endpoints are consumed.
+ */
+
+/** XIVAPI-supported language codes (TR-7: en, ja, de, fr). */
+export const XivApiLanguage = {
+  En: 'en',
+  Ja: 'ja',
+  De: 'de',
+  Fr: 'fr',
+} as const;
+
+export type XivApiLanguage = (typeof XivApiLanguage)[keyof typeof XivApiLanguage];
+
+/** Error envelope returned by all v2 endpoints on non-200 responses. */
+export interface XivApiErrorResponse {
+  readonly code: number;
+  readonly message: string;
+}
+
+/** Parameters for `GET /search`. */
+export interface XivApiSearchParams {
+  /** Search query string (v2 query syntax). */
+  readonly query?: string;
+  /** Comma-separated sheet names to search (e.g. "Quest,Item"). */
+  readonly sheets?: string;
+  /** Cursor UUID for pagination (returned as `next` in a prior response). */
+  readonly cursor?: string;
+  readonly limit?: number;
+  readonly language?: XivApiLanguage;
+  /** Field filter for row data (dot notation, e.g. "Name,Icon"). */
+  readonly fields?: string;
+  /** Field filter for transient row data. */
+  readonly transient?: string;
+}
+
+/** A single search hit from `GET /search`. */
+export interface XivApiSearchResultEntry {
+  readonly score: number;
+  readonly sheet: string;
+  readonly row_id: number;
+  readonly subrow_id?: number;
+  readonly fields: Record<string, unknown>;
+  readonly transient?: Record<string, unknown>;
+}
+
+/** Response envelope from `GET /search`. */
+export interface XivApiSearchResult {
+  readonly next?: string;
+  readonly results: readonly XivApiSearchResultEntry[];
+  readonly schema: string;
+  readonly version: string;
+}
+
+/** Optional parameters for `GET /sheet/{sheet}/{row}`. */
+export interface XivApiRowParams {
+  readonly language?: XivApiLanguage;
+  readonly fields?: string;
+  readonly transient?: string;
+}
+
+/** Response from `GET /sheet/{sheet}/{row}`. */
+export interface XivApiRowResponse {
+  readonly row_id: number;
+  readonly subrow_id?: number;
+  readonly fields: Record<string, unknown>;
+  readonly transient?: Record<string, unknown>;
+  readonly schema: string;
+  readonly version: string;
+}
+
+/** Public contract for the XIVAPI v2 HTTP client. */
+export interface XivApiClient {
+  search(params: XivApiSearchParams): Promise<XivApiSearchResult>;
+  getRow(sheet: string, row: number, params?: XivApiRowParams): Promise<XivApiRowResponse>;
+}

--- a/backend/tests/lib/config/constants.test.ts
+++ b/backend/tests/lib/config/constants.test.ts
@@ -8,6 +8,9 @@ import {
   RATE_LIMIT_REFILL_PER_MINUTE,
   REDACT,
   REQUEST_TIMEOUT_MS,
+  XIVAPI_BASE_URL,
+  XIVAPI_TIMEOUT_MS,
+  XIVAPI_RATE_LIMIT_PER_SECOND,
 } from '@src/lib/config/constants.js';
 
 describe('lib/config/constants', () => {
@@ -40,5 +43,11 @@ describe('lib/config/constants', () => {
   it('exports redaction config', () => {
     expect(REDACT.HEADER_NAMES).toEqual(['authorization', 'x-api-key', 'api-key', 'cookie']);
     expect(REDACT.QUERY_PARAMS).toEqual(['key', 'token', 'api_key', 'apikey', 'auth']);
+  });
+
+  it('exports XIVAPI constants', () => {
+    expect(XIVAPI_BASE_URL).toBe('https://v2.xivapi.com/api');
+    expect(XIVAPI_TIMEOUT_MS).toBe(5_000);
+    expect(XIVAPI_RATE_LIMIT_PER_SECOND).toBe(20);
   });
 });

--- a/backend/tests/lib/config/constants.test.ts
+++ b/backend/tests/lib/config/constants.test.ts
@@ -11,6 +11,7 @@ import {
   XIVAPI_BASE_URL,
   XIVAPI_TIMEOUT_MS,
   XIVAPI_RATE_LIMIT_PER_SECOND,
+  XIVAPI_RATE_LIMIT_BURST,
 } from '@src/lib/config/constants.js';
 
 describe('lib/config/constants', () => {
@@ -48,6 +49,7 @@ describe('lib/config/constants', () => {
   it('exports XIVAPI constants', () => {
     expect(XIVAPI_BASE_URL).toBe('https://v2.xivapi.com/api');
     expect(XIVAPI_TIMEOUT_MS).toBe(5_000);
-    expect(XIVAPI_RATE_LIMIT_PER_SECOND).toBe(20);
+    expect(XIVAPI_RATE_LIMIT_PER_SECOND).toBe(25);
+    expect(XIVAPI_RATE_LIMIT_BURST).toBe(50);
   });
 });

--- a/backend/tests/lib/http/fetchWithRetry.test.ts
+++ b/backend/tests/lib/http/fetchWithRetry.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchWithRetry, type FetchWithRetryOptions } from '@src/lib/http/fetchWithRetry.js';
+import { AppError } from '@src/lib/errors/AppError.js';
+import { ERROR_CODES } from '@chatxiv/cdm';
+import type pino from 'pino';
+
+function createMockLogger(): pino.Logger {
+  return { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } as unknown as pino.Logger;
+}
+
+const defaultOptions: FetchWithRetryOptions = {
+  timeoutMs: 5_000,
+  sourceName: 'TestAPI',
+};
+
+describe('lib/http/fetchWithRetry', () => {
+  const fetchMock = vi.fn();
+  let log: pino.Logger;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    log = createMockLogger();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function okJson(body: unknown): Partial<Response> {
+    return { ok: true, status: 200, json: () => Promise.resolve(body) } as Partial<Response>;
+  }
+
+  function errorResponse(status: number, retryAfter?: string): Partial<Response> {
+    const headers = new Headers();
+    if (retryAfter) headers.set('Retry-After', retryAfter);
+    return {
+      ok: false,
+      status,
+      headers,
+      json: () => Promise.resolve({ code: status, message: 'error' }),
+    } as Partial<Response>;
+  }
+
+  function expectSourceUnavailable(err: unknown): void {
+    expect(err).toBeInstanceOf(AppError);
+    const appErr = err as AppError;
+    expect(appErr.status).toBe(503);
+    expect(appErr.code).toBe(ERROR_CODES.SOURCE_UNAVAILABLE);
+  }
+
+  // ── Success ───────────────────────────────────────────────────────
+
+  describe('success', () => {
+    it('returns parsed JSON on 200', async () => {
+      fetchMock.mockResolvedValue(okJson({ id: 1 }));
+
+      const result = await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+
+      expect(result).toEqual({ id: 1 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── beforeAttempt hook ────────────────────────────────────────────
+
+  describe('beforeAttempt', () => {
+    it('calls beforeAttempt before each fetch', async () => {
+      const order: string[] = [];
+      const opts: FetchWithRetryOptions = {
+        ...defaultOptions,
+        beforeAttempt: vi.fn().mockImplementation(() => {
+          order.push('hook');
+          return Promise.resolve();
+        }),
+      };
+      fetchMock.mockImplementation(() => {
+        order.push('fetch');
+        return Promise.resolve(okJson({ ok: true }));
+      });
+
+      await fetchWithRetry('https://api.example.com/data', opts, log);
+
+      expect(order).toEqual(['hook', 'fetch']);
+    });
+  });
+
+  // ── Timeout ───────────────────────────────────────────────────────
+
+  describe('timeout', () => {
+    it('throws AppError.sourceUnavailable on TimeoutError', async () => {
+      fetchMock.mockRejectedValue(new DOMException('signal timed out', 'TimeoutError'));
+
+      try {
+        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expectSourceUnavailable(err);
+        expect((err as AppError).message).toMatch(/timed out/);
+        expect((err as AppError).message).toContain('TestAPI');
+      }
+    });
+
+    it('throws AppError.sourceUnavailable on AbortError', async () => {
+      const abort = new Error('aborted');
+      abort.name = 'AbortError';
+      fetchMock.mockRejectedValue(abort);
+
+      try {
+        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expectSourceUnavailable(err);
+        expect((err as AppError).message).toMatch(/timed out/);
+      }
+    });
+
+    it('throws AppError.sourceUnavailable on generic network error', async () => {
+      fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+      try {
+        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expectSourceUnavailable(err);
+        expect((err as AppError).message).toBe('fetch failed');
+      }
+    });
+
+    it('uses sourceName in fallback network error message', async () => {
+      fetchMock.mockRejectedValue('non-error throw');
+
+      try {
+        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expectSourceUnavailable(err);
+        expect((err as AppError).message).toBe('TestAPI network error');
+      }
+    });
+  });
+
+  // ── Retry on 429 / 5xx ────────────────────────────────────────────
+
+  describe('retry', () => {
+    it('retries on 429 with exponential backoff', async () => {
+      vi.useFakeTimers();
+
+      fetchMock.mockResolvedValueOnce(errorResponse(429)).mockResolvedValueOnce(okJson({ id: 1 }));
+
+      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      const result = await promise;
+
+      expect(result).toEqual({ id: 1 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it('respects Retry-After header on 429', async () => {
+      vi.useFakeTimers();
+
+      fetchMock
+        .mockResolvedValueOnce(errorResponse(429, '3'))
+        .mockResolvedValueOnce(okJson({ id: 1 }));
+
+      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      const result = await promise;
+
+      expect(result).toEqual({ id: 1 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it('retries on 5xx responses', async () => {
+      vi.useFakeTimers();
+
+      fetchMock
+        .mockResolvedValueOnce(errorResponse(502))
+        .mockResolvedValueOnce(errorResponse(503))
+        .mockResolvedValueOnce(okJson({ id: 1 }));
+
+      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(2_000);
+      const result = await promise;
+
+      expect(result).toEqual({ id: 1 });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      vi.useRealTimers();
+    });
+
+    it('throws AppError after exhausting all retries', async () => {
+      vi.useFakeTimers();
+
+      fetchMock.mockResolvedValue(errorResponse(500));
+
+      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+      promise.catch(() => {});
+
+      await vi.advanceTimersByTimeAsync(7_000);
+
+      try {
+        await promise;
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expectSourceUnavailable(err);
+        expect((err as AppError).message).toMatch(/500/);
+        expect((err as AppError).message).toMatch(/retries/);
+        expect((err as AppError).message).toContain('TestAPI');
+      }
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+
+      vi.useRealTimers();
+    });
+
+    it('does not retry on non-retryable 4xx', async () => {
+      fetchMock.mockResolvedValue(errorResponse(404));
+
+      try {
+        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expectSourceUnavailable(err);
+        expect((err as AppError).message).toMatch(/404/);
+        expect((err as AppError).message).toContain('TestAPI');
+      }
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports custom maxRetries and backoffBaseMs', async () => {
+      vi.useFakeTimers();
+
+      fetchMock.mockResolvedValueOnce(errorResponse(500)).mockResolvedValueOnce(okJson({ id: 1 }));
+
+      const opts: FetchWithRetryOptions = {
+        ...defaultOptions,
+        maxRetries: 1,
+        backoffBaseMs: 500,
+      };
+      const promise = fetchWithRetry('https://api.example.com/data', opts, log);
+
+      await vi.advanceTimersByTimeAsync(500);
+      const result = await promise;
+
+      expect(result).toEqual({ id: 1 });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+  });
+
+  // ── Logging ───────────────────────────────────────────────────────
+
+  describe('logging', () => {
+    it('logs a warning on retryable errors', async () => {
+      vi.useFakeTimers();
+
+      fetchMock.mockResolvedValueOnce(errorResponse(503)).mockResolvedValueOnce(okJson({ id: 1 }));
+
+      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await promise;
+
+      expect(log.warn).toHaveBeenCalledTimes(1);
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 503, attempt: 0 }),
+        expect.stringContaining('retryable')
+      );
+
+      vi.useRealTimers();
+    });
+
+    it('includes sourceName in log message', async () => {
+      vi.useFakeTimers();
+
+      fetchMock.mockResolvedValueOnce(errorResponse(429)).mockResolvedValueOnce(okJson({ id: 1 }));
+
+      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await promise;
+
+      expect(log.warn).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('TestAPI'));
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/backend/tests/lib/http/fetchWithRetry.test.ts
+++ b/backend/tests/lib/http/fetchWithRetry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fetchWithRetry, type FetchWithRetryOptions } from '@src/lib/http/fetchWithRetry.js';
+import { RetryingHttpClient, type RetryingHttpClientConfig } from '@src/lib/http/fetchWithRetry.js';
 import { AppError } from '@src/lib/errors/AppError.js';
+import { requestContext } from '@src/lib/request/requestContext.js';
 import { ERROR_CODES } from '@chatxiv/cdm';
 import type pino from 'pino';
 
@@ -8,12 +9,21 @@ function createMockLogger(): pino.Logger {
   return { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } as unknown as pino.Logger;
 }
 
-const defaultOptions: FetchWithRetryOptions = {
+/** Minimal concrete client for exercising `RetryingHttpClient.fetchJson`. */
+function createTestHttpClient(config: RetryingHttpClientConfig): RetryingHttpClient {
+  return new (class extends RetryingHttpClient {
+    constructor(c: RetryingHttpClientConfig) {
+      super(c);
+    }
+  })(config);
+}
+
+const defaultOptions: RetryingHttpClientConfig = {
   timeoutMs: 5_000,
   sourceName: 'TestAPI',
 };
 
-describe('lib/http/fetchWithRetry', () => {
+describe('RetryingHttpClient', () => {
   const fetchMock = vi.fn();
   let log: pino.Logger;
 
@@ -55,9 +65,29 @@ describe('lib/http/fetchWithRetry', () => {
     it('returns parsed JSON on 200', async () => {
       fetchMock.mockResolvedValue(okJson({ id: 1 }));
 
-      const result = await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+      const result = await createTestHttpClient(defaultOptions).fetchJson(
+        'https://api.example.com/data',
+        log
+      );
 
       expect(result).toEqual({ id: 1 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns blob on 200 from fetchBlob', async () => {
+      const blob = new Blob(['x']);
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(blob),
+      } as Partial<Response>);
+
+      const result = await createTestHttpClient(defaultOptions).fetchBlob(
+        'https://api.example.com/asset',
+        log
+      );
+
+      expect(result).toBe(blob);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
@@ -67,10 +97,10 @@ describe('lib/http/fetchWithRetry', () => {
   describe('beforeAttempt', () => {
     it('calls beforeAttempt before each fetch', async () => {
       const order: string[] = [];
-      const opts: FetchWithRetryOptions = {
+      const opts: RetryingHttpClientConfig = {
         ...defaultOptions,
-        beforeAttempt: vi.fn().mockImplementation(() => {
-          order.push('hook');
+        beforeAttempt: vi.fn().mockImplementation((ctx) => {
+          order.push(`hook:${ctx.url}`);
           return Promise.resolve();
         }),
       };
@@ -79,9 +109,27 @@ describe('lib/http/fetchWithRetry', () => {
         return Promise.resolve(okJson({ ok: true }));
       });
 
-      await fetchWithRetry('https://api.example.com/data', opts, log);
+      await createTestHttpClient(opts).fetchJson('https://api.example.com/data', log);
 
-      expect(order).toEqual(['hook', 'fetch']);
+      expect(order).toEqual(['hook:https://api.example.com/data', 'fetch']);
+    });
+
+    it('passes requestId from requestContext when present', async () => {
+      const hook = vi.fn().mockResolvedValue(undefined);
+      const opts: RetryingHttpClientConfig = {
+        ...defaultOptions,
+        beforeAttempt: hook,
+      };
+      fetchMock.mockResolvedValue(okJson({ ok: true }));
+
+      await requestContext.run({ requestId: 'incoming-req-99' }, () =>
+        createTestHttpClient(opts).fetchJson('https://api.example.com/data', log)
+      );
+
+      expect(hook).toHaveBeenCalledWith({
+        url: 'https://api.example.com/data',
+        requestId: 'incoming-req-99',
+      });
     });
   });
 
@@ -92,7 +140,7 @@ describe('lib/http/fetchWithRetry', () => {
       fetchMock.mockRejectedValue(new DOMException('signal timed out', 'TimeoutError'));
 
       try {
-        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        await createTestHttpClient(defaultOptions).fetchJson('https://api.example.com/data', log);
         expect.unreachable('should have thrown');
       } catch (err) {
         expectSourceUnavailable(err);
@@ -107,7 +155,7 @@ describe('lib/http/fetchWithRetry', () => {
       fetchMock.mockRejectedValue(abort);
 
       try {
-        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        await createTestHttpClient(defaultOptions).fetchJson('https://api.example.com/data', log);
         expect.unreachable('should have thrown');
       } catch (err) {
         expectSourceUnavailable(err);
@@ -119,7 +167,7 @@ describe('lib/http/fetchWithRetry', () => {
       fetchMock.mockRejectedValue(new TypeError('fetch failed'));
 
       try {
-        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        await createTestHttpClient(defaultOptions).fetchJson('https://api.example.com/data', log);
         expect.unreachable('should have thrown');
       } catch (err) {
         expectSourceUnavailable(err);
@@ -131,7 +179,7 @@ describe('lib/http/fetchWithRetry', () => {
       fetchMock.mockRejectedValue('non-error throw');
 
       try {
-        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        await createTestHttpClient(defaultOptions).fetchJson('https://api.example.com/data', log);
         expect.unreachable('should have thrown');
       } catch (err) {
         expectSourceUnavailable(err);
@@ -148,7 +196,10 @@ describe('lib/http/fetchWithRetry', () => {
 
       fetchMock.mockResolvedValueOnce(errorResponse(429)).mockResolvedValueOnce(okJson({ id: 1 }));
 
-      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+      const promise = createTestHttpClient(defaultOptions).fetchJson(
+        'https://api.example.com/data',
+        log
+      );
 
       await vi.advanceTimersByTimeAsync(1_000);
       const result = await promise;
@@ -166,7 +217,10 @@ describe('lib/http/fetchWithRetry', () => {
         .mockResolvedValueOnce(errorResponse(429, '3'))
         .mockResolvedValueOnce(okJson({ id: 1 }));
 
-      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+      const promise = createTestHttpClient(defaultOptions).fetchJson(
+        'https://api.example.com/data',
+        log
+      );
 
       await vi.advanceTimersByTimeAsync(3_000);
       const result = await promise;
@@ -185,7 +239,10 @@ describe('lib/http/fetchWithRetry', () => {
         .mockResolvedValueOnce(errorResponse(503))
         .mockResolvedValueOnce(okJson({ id: 1 }));
 
-      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+      const promise = createTestHttpClient(defaultOptions).fetchJson(
+        'https://api.example.com/data',
+        log
+      );
 
       await vi.advanceTimersByTimeAsync(1_000);
       await vi.advanceTimersByTimeAsync(2_000);
@@ -202,7 +259,10 @@ describe('lib/http/fetchWithRetry', () => {
 
       fetchMock.mockResolvedValue(errorResponse(500));
 
-      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+      const promise = createTestHttpClient(defaultOptions).fetchJson(
+        'https://api.example.com/data',
+        log
+      );
       promise.catch(() => {});
 
       await vi.advanceTimersByTimeAsync(7_000);
@@ -226,7 +286,7 @@ describe('lib/http/fetchWithRetry', () => {
       fetchMock.mockResolvedValue(errorResponse(404));
 
       try {
-        await fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+        await createTestHttpClient(defaultOptions).fetchJson('https://api.example.com/data', log);
         expect.unreachable('should have thrown');
       } catch (err) {
         expectSourceUnavailable(err);
@@ -242,12 +302,12 @@ describe('lib/http/fetchWithRetry', () => {
 
       fetchMock.mockResolvedValueOnce(errorResponse(500)).mockResolvedValueOnce(okJson({ id: 1 }));
 
-      const opts: FetchWithRetryOptions = {
+      const opts: RetryingHttpClientConfig = {
         ...defaultOptions,
         maxRetries: 1,
         backoffBaseMs: 500,
       };
-      const promise = fetchWithRetry('https://api.example.com/data', opts, log);
+      const promise = createTestHttpClient(opts).fetchJson('https://api.example.com/data', log);
 
       await vi.advanceTimersByTimeAsync(500);
       const result = await promise;
@@ -267,7 +327,10 @@ describe('lib/http/fetchWithRetry', () => {
 
       fetchMock.mockResolvedValueOnce(errorResponse(503)).mockResolvedValueOnce(okJson({ id: 1 }));
 
-      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+      const promise = createTestHttpClient(defaultOptions).fetchJson(
+        'https://api.example.com/data',
+        log
+      );
 
       await vi.advanceTimersByTimeAsync(1_000);
       await promise;
@@ -286,7 +349,10 @@ describe('lib/http/fetchWithRetry', () => {
 
       fetchMock.mockResolvedValueOnce(errorResponse(429)).mockResolvedValueOnce(okJson({ id: 1 }));
 
-      const promise = fetchWithRetry('https://api.example.com/data', defaultOptions, log);
+      const promise = createTestHttpClient(defaultOptions).fetchJson(
+        'https://api.example.com/data',
+        log
+      );
 
       await vi.advanceTimersByTimeAsync(1_000);
       await promise;

--- a/backend/tests/lib/xivapi/XIVApiClient.test.ts
+++ b/backend/tests/lib/xivapi/XIVApiClient.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createXivApiClient, type XivApiClientConfig } from '@src/lib/xivapi/XIVApiClient.js';
+import { XivApiSchemaFormat } from '@src/lib/xivapi/types.js';
+import { requestContext } from '@src/lib/request/requestContext.js';
 import type { TokenBucket } from '@src/lib/xivapi/throttle.js';
 import type pino from 'pino';
 
@@ -34,6 +36,14 @@ describe('lib/xivapi/XIVApiClient', () => {
 
   function okJson(body: unknown): Partial<Response> {
     return { ok: true, status: 200, json: () => Promise.resolve(body) } as Partial<Response>;
+  }
+
+  function okBlob(blob: Blob): Partial<Response> {
+    return {
+      ok: true,
+      status: 200,
+      blob: () => Promise.resolve(blob),
+    } as Partial<Response>;
   }
 
   // ── search URL building ───────────────────────────────────────────
@@ -90,6 +100,17 @@ describe('lib/xivapi/XIVApiClient', () => {
       expect(url.searchParams.has('language')).toBe(false);
       expect(url.searchParams.has('cursor')).toBe(false);
     });
+
+    it('passes version and schema when provided', async () => {
+      fetchMock.mockResolvedValue(okJson({ results: [], schema: 's', version: 'v' }));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.search({ version: 'latest', schema: 'source@7.0' });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.searchParams.get('version')).toBe('latest');
+      expect(url.searchParams.get('schema')).toBe('source@7.0');
+    });
   });
 
   // ── getRow URL building ───────────────────────────────────────────
@@ -134,6 +155,109 @@ describe('lib/xivapi/XIVApiClient', () => {
       const url = new URL(fetchMock.mock.calls[0][0] as string);
       expect(url.pathname).toBe('/api/sheet/GCRankGridaniaFemaleText/1');
     });
+
+    it('supports RowSpecifier strings including subrow', async () => {
+      fetchMock.mockResolvedValue(
+        okJson({ row_id: 1, subrow_id: 2, fields: {}, schema: 's', version: 'v' })
+      );
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.getRow('Sheet', '10:2');
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/sheet/Sheet/10%3A2');
+    });
+
+    it('passes schema query on getRow', async () => {
+      fetchMock.mockResolvedValue(okJson({ row_id: 1, fields: {}, schema: 's', version: 'v' }));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.getRow('Item', 1, { schema: 'source@latest' });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.searchParams.get('schema')).toBe('source@latest');
+    });
+  });
+
+  describe('listSheets', () => {
+    it('builds list URL with optional version', async () => {
+      fetchMock.mockResolvedValue(okJson({ sheets: [] }));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.listSheets({ version: 'latest' });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/sheet');
+      expect(url.searchParams.get('version')).toBe('latest');
+    });
+  });
+
+  describe('listSheetRows', () => {
+    it('builds sheet rows URL with pagination and reader params', async () => {
+      fetchMock.mockResolvedValue(okJson({ rows: [], schema: 's', version: 'v' }));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.listSheetRows('Item', {
+        limit: 5,
+        after: '100',
+        fields: 'Name',
+        version: '7.0',
+      });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/sheet/Item');
+      expect(url.searchParams.get('limit')).toBe('5');
+      expect(url.searchParams.get('after')).toBe('100');
+      expect(url.searchParams.get('fields')).toBe('Name');
+      expect(url.searchParams.get('version')).toBe('7.0');
+    });
+  });
+
+  describe('listVersions', () => {
+    it('requests /version', async () => {
+      fetchMock.mockResolvedValue(okJson({ versions: [] }));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.listVersions();
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/version');
+    });
+  });
+
+  describe('getAsset', () => {
+    it('builds asset URL with path, format, and version', async () => {
+      const blob = new Blob([]);
+      fetchMock.mockResolvedValue(okBlob(blob));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      const result = await client.getAsset({
+        path: 'ui/icon/051000/051474_hr1.tex',
+        format: XivApiSchemaFormat.Png,
+        version: 'latest',
+      });
+
+      expect(result).toBe(blob);
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/asset');
+      expect(url.searchParams.get('path')).toBe('ui/icon/051000/051474_hr1.tex');
+      expect(url.searchParams.get('format')).toBe('png');
+      expect(url.searchParams.get('version')).toBe('latest');
+    });
+  });
+
+  describe('getMapAsset', () => {
+    it('builds map asset path and optional version', async () => {
+      const blob = new Blob([]);
+      fetchMock.mockResolvedValue(okBlob(blob));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.getMapAsset({ territory: 's1d1', index: '00' }, { version: '7.0' });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/asset/map/s1d1/00');
+      expect(url.searchParams.get('version')).toBe('7.0');
+    });
   });
 
   // ── Throttle delegation ───────────────────────────────────────────
@@ -156,6 +280,22 @@ describe('lib/xivapi/XIVApiClient', () => {
       await client.search({});
 
       expect(order).toEqual(['throttle', 'fetch']);
+      expect(mockThrottle.consume).toHaveBeenCalledWith({
+        url: 'https://v2.xivapi.com/api/search',
+      });
+    });
+
+    it('forwards requestId into throttle.consume when requestContext is active', async () => {
+      const mockThrottle: TokenBucket = { consume: vi.fn().mockResolvedValue(undefined) };
+      fetchMock.mockResolvedValue(okJson({ results: [], schema: 's', version: 'v' }));
+
+      const client = createXivApiClient(defaultConfig, mockThrottle, log);
+      await requestContext.run({ requestId: 'chat-req-7' }, () => client.search({}));
+
+      expect(mockThrottle.consume).toHaveBeenCalledWith({
+        url: 'https://v2.xivapi.com/api/search',
+        requestId: 'chat-req-7',
+      });
     });
   });
 

--- a/backend/tests/lib/xivapi/XIVApiClient.test.ts
+++ b/backend/tests/lib/xivapi/XIVApiClient.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createXivApiClient, type XivApiClientConfig } from '@src/lib/xivapi/XIVApiClient.js';
+import type { TokenBucket } from '@src/lib/xivapi/throttle.js';
+import type pino from 'pino';
+
+function createMockLogger(): pino.Logger {
+  return { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } as unknown as pino.Logger;
+}
+
+function createMockThrottle(): TokenBucket {
+  return { consume: vi.fn().mockResolvedValue(undefined) };
+}
+
+const defaultConfig: XivApiClientConfig = {
+  baseUrl: 'https://v2.xivapi.com/api',
+  timeoutMs: 5_000,
+};
+
+describe('lib/xivapi/XIVApiClient', () => {
+  const fetchMock = vi.fn();
+  let log: pino.Logger;
+  let throttle: TokenBucket;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    log = createMockLogger();
+    throttle = createMockThrottle();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function okJson(body: unknown): Partial<Response> {
+    return { ok: true, status: 200, json: () => Promise.resolve(body) } as Partial<Response>;
+  }
+
+  // ── search URL building ───────────────────────────────────────────
+
+  describe('search', () => {
+    it('builds URL with v2 search params', async () => {
+      const body = { next: undefined, results: [], schema: 's', version: 'v' };
+      fetchMock.mockResolvedValue(okJson(body));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      const result = await client.search({
+        query: 'Name~"Potion"',
+        sheets: 'Item',
+        limit: 10,
+        language: 'ja',
+        fields: 'Name,Icon',
+        transient: 'Description',
+      });
+
+      expect(result).toEqual(body);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/search');
+      expect(url.searchParams.get('query')).toBe('Name~"Potion"');
+      expect(url.searchParams.get('sheets')).toBe('Item');
+      expect(url.searchParams.get('limit')).toBe('10');
+      expect(url.searchParams.get('language')).toBe('ja');
+      expect(url.searchParams.get('fields')).toBe('Name,Icon');
+      expect(url.searchParams.get('transient')).toBe('Description');
+    });
+
+    it('builds cursor-based pagination URL', async () => {
+      fetchMock.mockResolvedValue(okJson({ results: [], schema: 's', version: 'v' }));
+
+      const cursor = 'bbe61a5e-7d22-41ec-9f5a-711c967c5624';
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.search({ cursor });
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.searchParams.get('cursor')).toBe(cursor);
+    });
+
+    it('omits optional params when not provided', async () => {
+      fetchMock.mockResolvedValue(okJson({ results: [], schema: 's', version: 'v' }));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.search({});
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/search');
+      expect(url.searchParams.has('query')).toBe(false);
+      expect(url.searchParams.has('sheets')).toBe(false);
+      expect(url.searchParams.has('language')).toBe(false);
+      expect(url.searchParams.has('cursor')).toBe(false);
+    });
+  });
+
+  // ── getRow URL building ───────────────────────────────────────────
+
+  describe('getRow', () => {
+    it('builds URL with sheet name, row id, and optional params', async () => {
+      const body = { row_id: 100, fields: { Name: 'Test' }, schema: 's', version: 'v' };
+      fetchMock.mockResolvedValue(okJson(body));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      const result = await client.getRow('Quest', 100, {
+        language: 'fr',
+        fields: 'Name',
+      });
+
+      expect(result).toEqual(body);
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/sheet/Quest/100');
+      expect(url.searchParams.get('language')).toBe('fr');
+      expect(url.searchParams.get('fields')).toBe('Name');
+    });
+
+    it('omits optional params when not provided', async () => {
+      fetchMock.mockResolvedValue(okJson({ row_id: 1, fields: {}, schema: 's', version: 'v' }));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.getRow('Item', 1);
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/sheet/Item/1');
+      expect(url.searchParams.has('language')).toBe(false);
+      expect(url.searchParams.has('fields')).toBe(false);
+      expect(url.searchParams.has('transient')).toBe(false);
+    });
+
+    it('encodes sheet names with special characters', async () => {
+      fetchMock.mockResolvedValue(okJson({ row_id: 1, fields: {}, schema: 's', version: 'v' }));
+
+      const client = createXivApiClient(defaultConfig, throttle, log);
+      await client.getRow('GCRankGridaniaFemaleText', 1);
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/sheet/GCRankGridaniaFemaleText/1');
+    });
+  });
+
+  // ── Throttle delegation ───────────────────────────────────────────
+
+  describe('throttle integration', () => {
+    it('awaits throttle.consume() before each fetch', async () => {
+      const order: string[] = [];
+      const mockThrottle: TokenBucket = {
+        consume: vi.fn().mockImplementation(() => {
+          order.push('throttle');
+          return Promise.resolve();
+        }),
+      };
+      fetchMock.mockImplementation(() => {
+        order.push('fetch');
+        return Promise.resolve(okJson({ results: [], schema: 's', version: 'v' }));
+      });
+
+      const client = createXivApiClient(defaultConfig, mockThrottle, log);
+      await client.search({});
+
+      expect(order).toEqual(['throttle', 'fetch']);
+    });
+  });
+
+  // ── Base URL trailing-slash handling ───────────────────────────────
+
+  describe('base URL normalization', () => {
+    it('works with trailing slash in base URL', async () => {
+      fetchMock.mockResolvedValue(okJson({ results: [], schema: 's', version: 'v' }));
+
+      const config: XivApiClientConfig = {
+        baseUrl: 'https://v2.xivapi.com/api/',
+        timeoutMs: 5_000,
+      };
+      const client = createXivApiClient(config, throttle, log);
+      await client.search({});
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/search');
+    });
+
+    it('works without trailing slash in base URL', async () => {
+      fetchMock.mockResolvedValue(okJson({ row_id: 1, fields: {}, schema: 's', version: 'v' }));
+
+      const config: XivApiClientConfig = {
+        baseUrl: 'https://v2.xivapi.com/api',
+        timeoutMs: 5_000,
+      };
+      const client = createXivApiClient(config, throttle, log);
+      await client.getRow('Item', 42);
+
+      const url = new URL(fetchMock.mock.calls[0][0] as string);
+      expect(url.pathname).toBe('/api/sheet/Item/42');
+    });
+  });
+});

--- a/backend/tests/lib/xivapi/throttle.test.ts
+++ b/backend/tests/lib/xivapi/throttle.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTokenBucket } from '@src/lib/xivapi/throttle.js';
+
+describe('lib/xivapi/throttle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves immediately when tokens are available', async () => {
+    const bucket = createTokenBucket(10);
+    await expect(bucket.consume()).resolves.toBeUndefined();
+  });
+
+  it('allows burst up to tokensPerSecond without delay', async () => {
+    const bucket = createTokenBucket(5);
+    for (let i = 0; i < 5; i++) {
+      await expect(bucket.consume()).resolves.toBeUndefined();
+    }
+  });
+
+  it('delays when tokens are exhausted', async () => {
+    const bucket = createTokenBucket(2);
+
+    await bucket.consume();
+    await bucket.consume();
+
+    let resolved = false;
+    const pending = bucket.consume().then(() => {
+      resolved = true;
+    });
+
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
+
+    expect(resolved).toBe(true);
+  });
+
+  it('refills tokens over time', async () => {
+    const bucket = createTokenBucket(5);
+
+    for (let i = 0; i < 5; i++) {
+      await bucket.consume();
+    }
+
+    vi.advanceTimersByTime(1_000);
+
+    for (let i = 0; i < 5; i++) {
+      await expect(bucket.consume()).resolves.toBeUndefined();
+    }
+  });
+
+  it('caps tokens at bucket capacity', async () => {
+    const bucket = createTokenBucket(3);
+
+    vi.advanceTimersByTime(5_000);
+
+    await bucket.consume();
+    await bucket.consume();
+    await bucket.consume();
+
+    let resolved = false;
+    const pending = bucket.consume().then(() => {
+      resolved = true;
+    });
+
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(334);
+    await pending;
+
+    expect(resolved).toBe(true);
+  });
+});

--- a/backend/tests/lib/xivapi/throttle.test.ts
+++ b/backend/tests/lib/xivapi/throttle.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type pino from 'pino';
 import { createTokenBucket } from '@src/lib/xivapi/throttle.js';
+
+function createMockLogger(): pino.Logger {
+  return { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } as unknown as pino.Logger;
+}
 
 describe('lib/xivapi/throttle', () => {
   beforeEach(() => {
@@ -15,9 +20,16 @@ describe('lib/xivapi/throttle', () => {
     await expect(bucket.consume()).resolves.toBeUndefined();
   });
 
-  it('allows burst up to tokensPerSecond without delay', async () => {
+  it('allows burst up to ratePerSecond without delay when burst equals rate', async () => {
     const bucket = createTokenBucket(5);
     for (let i = 0; i < 5; i++) {
+      await expect(bucket.consume()).resolves.toBeUndefined();
+    }
+  });
+
+  it('allows burst up to explicit burst capacity', async () => {
+    const bucket = createTokenBucket(5, 10);
+    for (let i = 0; i < 10; i++) {
       await expect(bucket.consume()).resolves.toBeUndefined();
     }
   });
@@ -75,5 +87,30 @@ describe('lib/xivapi/throttle', () => {
     await pending;
 
     expect(resolved).toBe(true);
+  });
+
+  it('warns when empty and a logger is configured', async () => {
+    const log = createMockLogger();
+    const bucket = createTokenBucket(2, 2, log);
+
+    await bucket.consume();
+    await bucket.consume();
+
+    const pending = bucket.consume({ url: 'https://example.com/x' });
+
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        waitMs: expect.any(Number),
+        tokens: expect.any(Number),
+        ratePerSecond: 2,
+        burstCapacity: 2,
+        url: 'https://example.com/x',
+      }),
+      'Token bucket empty; awaiting token refill'
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3935,6 +3935,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3952,6 +3953,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3969,6 +3971,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3986,6 +3989,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4003,6 +4007,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4020,6 +4025,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4037,6 +4043,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4054,6 +4061,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4071,6 +4079,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4088,6 +4097,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4105,6 +4115,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4122,6 +4133,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4139,6 +4151,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4156,6 +4169,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4173,6 +4187,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4190,6 +4205,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4207,6 +4223,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4241,6 +4258,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4275,6 +4293,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4309,6 +4328,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4326,6 +4346,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4343,6 +4364,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10340,8 +10362,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "license": "MIT"
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -12180,6 +12203,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12197,6 +12221,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12214,6 +12239,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12231,6 +12257,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "pino-loki": "^3.0.0",
         "reflect-metadata": "^0.2.2",
         "swagger-ui-express": "^5.0.1",
-        "tsyringe": "^4.8.0"
+        "tsyringe": "^4.8.0",
+        "typescript-retry-decorator": "^2.5.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -676,7 +677,7 @@
         "prettier": "^3.4.0",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.57.0",
-        "vite": "^6.4.2",
+        "vite": "6.4.2",
         "vitest": "^4.1.0"
       },
       "engines": {
@@ -11837,6 +11838,11 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/typescript-retry-decorator": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/typescript-retry-decorator/-/typescript-retry-decorator-2.5.4.tgz",
+      "integrity": "sha512-nsnF8EYN0NCO03N0enWt8P3t0l2WVZKNfOd6+OmZ7Teu5E6CTHf9/q/VbgBuAw5WVZr0VaLfIUmOA/mFPLT/sQ=="
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.41",


### PR DESCRIPTION
- Add reusable `fetchWithRetry` module (`backend/src/lib/http/fetchWithRetry.ts`) with exponential backoff, `Retry-After` support, configurable retries, and a `beforeAttempt` hook for throttling
- Rewrite XIVAPI client for v2 endpoints (`/search`, `/sheet/{sheet}/{row}`), cursor-based pagination, v2 query syntax, and no API key (v2 is open)
- Remove `XivApiError` / `XivApiTimeoutError` custom error classes and barrel `index.ts`; all failures throw `AppError.sourceUnavailable()` to bubble through the error middleware as 503
- Update `XIVAPI_BASE_URL` to `https://v2.xivapi.com/api`
- Fix lodash high-severity audit vulnerability via `npm audit fix`
<img width="1874" height="378" alt="image" src="https://github.com/user-attachments/assets/e31af716-10c9-4062-9f1f-4765f7297656" />
