### PR TITLE
feat: add chat source dropdown and plumb source metadata

### DIFF
--- a/frontend/src/features/chat/ChatConversationContext.tsx
+++ b/frontend/src/features/chat/ChatConversationContext.tsx
@@ -1,7 +1,8 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { useChatSession } from './ChatSessionContext';
 import { useChatConversation } from '../../hooks/useChatConversation';
-import { MessageRole, type Message } from '../../types/chat';
+import { ConversationRole } from '@chatxiv/cdm';
+import type { Message } from '../../types/chat';
 
 export type ChatConversationContextValue = {
   readonly messages: Message[];
@@ -25,7 +26,7 @@ export function ChatConversationProvider({ children }: { readonly children: Reac
   );
 
   const isEphemeralDirty =
-    messages.some((m) => m.role === MessageRole.User) || inputValue.trim().length > 0;
+    messages.some((m) => m.role === ConversationRole.User) || inputValue.trim().length > 0;
 
   const value = useMemo(
     (): ChatConversationContextValue => ({

--- a/frontend/src/features/chat/MessageFeedbackBar.module.css
+++ b/frontend/src/features/chat/MessageFeedbackBar.module.css
@@ -24,7 +24,7 @@
 .feedbackCluster {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.125rem;
 }
 
 .thumbButton {

--- a/frontend/src/features/chat/MessageList.module.css
+++ b/frontend/src/features/chat/MessageList.module.css
@@ -42,3 +42,22 @@
   border: 1px solid var(--border);
   margin-right: auto;
 }
+
+.footerRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 0.5rem;
+  row-gap: 0.25rem;
+  margin-top: 0.5rem;
+  max-width: 100%;
+}
+
+.separator {
+  color: var(--muted-foreground);
+  opacity: 0.3;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  user-select: none;
+  align-self: center;
+}

--- a/frontend/src/features/chat/MessageList.tsx
+++ b/frontend/src/features/chat/MessageList.tsx
@@ -1,5 +1,7 @@
-import { MessageRole, type Message } from '../../types/chat';
+import { ConversationRole } from '@chatxiv/cdm';
+import type { Message } from '../../types/chat';
 import { MessageFeedbackBar } from './MessageFeedbackBar';
+import { SourceDropdown } from './SourceDropdown';
 import styles from './MessageList.module.css';
 
 interface MessageListProps {
@@ -10,7 +12,7 @@ export function MessageList({ messages }: MessageListProps) {
   return (
     <div className={styles.wrapper}>
       {messages.map((message) =>
-        message.role === MessageRole.User ? (
+        message.role === ConversationRole.User ? (
           <div key={message.id} className={styles.user}>
             <p className={styles.bubbleText}>{message.text}</p>
           </div>
@@ -19,7 +21,15 @@ export function MessageList({ messages }: MessageListProps) {
             <div className={styles.assistant}>
               <p className={styles.bubbleText}>{message.text}</p>
             </div>
-            <MessageFeedbackBar messageId={message.id} />
+            <div className={styles.footerRow}>
+              <SourceDropdown sources={message.sources} />
+              {message.sources && message.sources.length > 0 && (
+                <span className={styles.separator} aria-hidden>
+                  |
+                </span>
+              )}
+              <MessageFeedbackBar messageId={message.id} />
+            </div>
           </div>
         )
       )}

--- a/frontend/src/features/chat/SourceDropdown.module.css
+++ b/frontend/src/features/chat/SourceDropdown.module.css
@@ -1,0 +1,98 @@
+.wrapper {
+  position: relative;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--foreground) 5%, transparent);
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.25;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.trigger:hover {
+  background: color-mix(in srgb, var(--foreground) 10%, transparent);
+  color: var(--foreground);
+}
+
+.trigger:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.panel {
+  position: absolute;
+  left: 0;
+  top: 100%;
+  z-index: 20;
+  margin-top: 0.75rem;
+  min-width: 14rem;
+  padding: 0.1rem 0;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--card);
+  box-shadow:
+    0 4px 6px -1px color-mix(in srgb, var(--foreground) 8%, transparent),
+    0 2px 4px -2px color-mix(in srgb, var(--foreground) 6%, transparent);
+  list-style: none;
+  margin-block: 0.375rem 0;
+  padding-inline-start: 0;
+}
+
+.sourceItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.275rem;
+  padding: 0.375rem 0.75rem;
+  list-style: none;
+}
+
+.sourceBullet {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  transform: translateY(0.318em);
+}
+
+.sourceBody {
+  min-width: 0;
+}
+
+.sourceItem + .sourceItem {
+  border-top: 1px solid var(--border);
+}
+
+.sourceLink {
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  font-weight: 500;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.sourceLink:hover {
+  text-decoration: underline;
+}
+
+.sourceName {
+  font-size: 0.8125rem;
+  line-height: 1.35;
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+.sourceMeta {
+  font-size: 0.6875rem;
+  color: var(--muted-foreground);
+  margin-top: 0.125rem;
+}

--- a/frontend/src/features/chat/SourceDropdown.tsx
+++ b/frontend/src/features/chat/SourceDropdown.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { BookOpen, ChevronDown, ChevronUp } from 'lucide-react';
+import type { SourceCitation } from '@chatxiv/cdm';
+import { useSourceMeta } from '../../hooks/useSourceMeta';
+import styles from './SourceDropdown.module.css';
+
+interface SourceDropdownProps {
+  readonly sources: readonly SourceCitation[] | undefined;
+}
+
+export function SourceDropdown({ sources }: SourceDropdownProps) {
+  const items = useSourceMeta(sources);
+  const [open, setOpen] = useState(false);
+  const triggerId = useId();
+  const panelId = useId();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        close();
+      }
+    }
+
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        close();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open, close]);
+
+  if (items.length === 0) return null;
+
+  const Chevron = open ? ChevronUp : ChevronDown;
+
+  return (
+    <div className={styles.wrapper} ref={wrapperRef}>
+      <button
+        type="button"
+        id={triggerId}
+        className={styles.trigger}
+        aria-expanded={open}
+        aria-controls={panelId}
+        aria-haspopup="listbox"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <BookOpen size={12} aria-hidden />
+        <span>Source</span>
+        <Chevron size={11} aria-hidden />
+      </button>
+
+      {open && (
+        <ul id={panelId} role="listbox" className={styles.panel}>
+          {items.map((item, i) => (
+            <li key={i} role="option" className={styles.sourceItem} aria-selected={false}>
+              <span className={styles.sourceBullet} aria-hidden>
+                &bull;
+              </span>
+              <div className={styles.sourceBody}>
+                {item.url ? (
+                  <a
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.sourceLink}
+                  >
+                    {item.label}
+                  </a>
+                ) : (
+                  <span className={styles.sourceName}>{item.label}</span>
+                )}
+                {item.patchOrDate && (
+                  <div className={styles.sourceMeta}>Last updated: {item.patchOrDate}</div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useChatConversation.ts
+++ b/frontend/src/hooks/useChatConversation.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { MessageRole, type Message } from '../types/chat';
+import { ConversationRole } from '@chatxiv/cdm';
+import type { Message } from '../types/chat';
 import { CHAT_THREAD_GREETING } from '../features/chat/chatThreadGreeting';
 import { ChatSessionLanding } from '../types/chatSession';
 import { createDemoChatAssistantPort, type ChatAssistantPort } from '../lib/chat/chatAssistantPort';
@@ -20,7 +21,7 @@ function makeThreadGreetingMessage(): Message {
   return {
     id: crypto.randomUUID(),
     text: CHAT_THREAD_GREETING,
-    role: MessageRole.Assistant,
+    role: ConversationRole.Assistant,
   };
 }
 
@@ -70,7 +71,7 @@ export function useChatConversation(
       const userMessage: Message = {
         id: crypto.randomUUID(),
         text: trimmed,
-        role: MessageRole.User,
+        role: ConversationRole.User,
       };
 
       setMessages((prev) => [...prev, userMessage]);
@@ -82,12 +83,13 @@ export function useChatConversation(
 
       void (async () => {
         try {
-          const { text: replyText } = await assistantPort.getReply(trimmed, ac.signal);
+          const reply = await assistantPort.getReply(trimmed, ac.signal);
           if (abortRef.current !== ac) return;
           const botMessage: Message = {
             id: crypto.randomUUID(),
-            text: replyText,
-            role: MessageRole.Assistant,
+            text: reply.text,
+            role: ConversationRole.Assistant,
+            sources: reply.sources,
           };
           setMessages((prev) => [...prev, botMessage]);
         } catch (e) {

--- a/frontend/src/hooks/useSourceMeta.ts
+++ b/frontend/src/hooks/useSourceMeta.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import type { SourceCitation } from '@chatxiv/cdm';
+
+export interface SourceDisplayItem {
+  readonly label: string;
+  readonly url?: string;
+  readonly patchOrDate?: string;
+}
+
+export function useSourceMeta(
+  sources: readonly SourceCitation[] | undefined
+): readonly SourceDisplayItem[] {
+  return useMemo(() => {
+    if (!sources || sources.length === 0) return [];
+    return sources.map((s) => ({
+      label: s.sourceName,
+      url: s.sourceUrl,
+      patchOrDate: s.patchOrDate ?? s.lastUpdated,
+    }));
+  }, [sources]);
+}

--- a/frontend/src/lib/chat/chatAssistantPort.ts
+++ b/frontend/src/lib/chat/chatAssistantPort.ts
@@ -1,9 +1,14 @@
+import type { SourceCitation } from '@chatxiv/cdm';
+
 /**
  * Abstraction for obtaining assistant text after a user message. The UI depends on this port,
  * not on HTTP details — swap `createDemoChatAssistantPort` for an implementation that calls
  * `chatxivApiRequest` (or streams) when the backend contract is ready.
  */
-export type AssistantReply = { readonly text: string };
+export type AssistantReply = {
+  readonly text: string;
+  readonly sources?: readonly SourceCitation[];
+};
 
 export interface ChatAssistantPort {
   getReply(userMessage: string, signal?: AbortSignal): Promise<AssistantReply>;
@@ -12,12 +17,23 @@ export interface ChatAssistantPort {
 export const DEMO_ASSISTANT_REPLY =
   "I'm MammetBot! This is a demo response. In a real implementation, I would provide helpful information about FFXIV!";
 
+export const DEMO_ASSISTANT_SOURCES: readonly SourceCitation[] = [
+  {
+    sourceName: 'The Lodestone (Official)',
+    sourceUrl: 'https://na.finalfantasyxiv.com/lodestone/',
+    patchOrDate: 'Patch 7.1',
+  },
+  {
+    sourceName: 'XIVAPI Item Database',
+  },
+];
+
 export function createDemoChatAssistantPort(delayMs = 1000): ChatAssistantPort {
   return {
     getReply(_userMessage, signal) {
       return new Promise((resolve, reject) => {
         const id = window.setTimeout(() => {
-          resolve({ text: DEMO_ASSISTANT_REPLY });
+          resolve({ text: DEMO_ASSISTANT_REPLY, sources: DEMO_ASSISTANT_SOURCES });
         }, delayMs);
 
         const onAbort = () => {

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,11 +1,9 @@
-export const MessageRole = {
-  User: 'user',
-  Assistant: 'assistant',
-} as const;
-export type MessageRole = (typeof MessageRole)[keyof typeof MessageRole];
+import { ConversationRole } from '@chatxiv/cdm';
+import type { SourceCitation } from '@chatxiv/cdm';
 
 export interface Message {
   id: string;
   text: string;
-  role: MessageRole;
+  role: ConversationRole;
+  sources?: readonly SourceCitation[];
 }

--- a/frontend/tests/features/chat/MessageList.test.tsx
+++ b/frontend/tests/features/chat/MessageList.test.tsx
@@ -1,15 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MessageList } from '@/features/chat/MessageList';
-import { MessageRole } from '@/types/chat';
+import { ConversationRole } from '@chatxiv/cdm';
+import type { SourceCitation } from '@chatxiv/cdm';
+
+const SOURCES: SourceCitation[] = [
+  {
+    sourceName: 'The Lodestone',
+    sourceUrl: 'https://lodestone.example.com',
+    patchOrDate: 'Patch 7.1',
+  },
+  { sourceName: 'XIVAPI' },
+];
 
 describe('MessageList', () => {
   it('renders user and assistant messages', () => {
     render(
       <MessageList
         messages={[
-          { id: '1', text: 'Hello', role: MessageRole.User },
-          { id: '2', text: 'Hi there', role: MessageRole.Assistant },
+          { id: '1', text: 'Hello', role: ConversationRole.User },
+          { id: '2', text: 'Hi there', role: ConversationRole.Assistant },
         ]}
       />
     );
@@ -21,13 +31,57 @@ describe('MessageList', () => {
     render(
       <MessageList
         messages={[
-          { id: '1', text: 'Hello', role: MessageRole.User },
-          { id: '2', text: 'Hi there', role: MessageRole.Assistant },
+          { id: '1', text: 'Hello', role: ConversationRole.User },
+          { id: '2', text: 'Hi there', role: ConversationRole.Assistant },
         ]}
       />
     );
     expect(
       screen.getByRole('group', { name: /Rate this assistant response/i })
     ).toBeInTheDocument();
+  });
+
+  it('renders source dropdown when assistant message has sources', () => {
+    render(
+      <MessageList
+        messages={[
+          { id: '1', text: 'Response', role: ConversationRole.Assistant, sources: SOURCES },
+        ]}
+      />
+    );
+    expect(screen.getByRole('button', { name: /source/i })).toBeInTheDocument();
+  });
+
+  it('renders separator between sources and feedback when sources exist', () => {
+    render(
+      <MessageList
+        messages={[
+          { id: '1', text: 'Response', role: ConversationRole.Assistant, sources: SOURCES },
+        ]}
+      />
+    );
+    expect(screen.getByText('|')).toBeInTheDocument();
+  });
+
+  it('does not render source dropdown or separator when sources are absent', () => {
+    render(
+      <MessageList messages={[{ id: '1', text: 'Response', role: ConversationRole.Assistant }]} />
+    );
+    expect(screen.queryByRole('button', { name: /source/i })).not.toBeInTheDocument();
+    expect(screen.queryByText('|')).not.toBeInTheDocument();
+  });
+
+  it('opens source dropdown to show sources in footer row', () => {
+    render(
+      <MessageList
+        messages={[
+          { id: '1', text: 'Response', role: ConversationRole.Assistant, sources: SOURCES },
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(screen.getByText('The Lodestone')).toBeInTheDocument();
+    expect(screen.getByText('XIVAPI')).toBeInTheDocument();
   });
 });

--- a/frontend/tests/features/chat/SourceDropdown.test.tsx
+++ b/frontend/tests/features/chat/SourceDropdown.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SourceDropdown } from '@/features/chat/SourceDropdown';
+import type { SourceCitation } from '@chatxiv/cdm';
+
+const FULL_SOURCE: SourceCitation = {
+  sourceName: 'The Lodestone',
+  sourceUrl: 'https://lodestone.example.com',
+  patchOrDate: 'Patch 7.1',
+};
+
+const MINIMAL_SOURCE: SourceCitation = {
+  sourceName: 'XIVAPI',
+};
+
+describe('SourceDropdown', () => {
+  it('renders nothing when sources is undefined', () => {
+    const { container } = render(<SourceDropdown sources={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when sources is empty', () => {
+    const { container } = render(<SourceDropdown sources={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a trigger button with "Source" text', () => {
+    render(<SourceDropdown sources={[FULL_SOURCE]} />);
+    expect(screen.getByRole('button', { name: /source/i })).toBeInTheDocument();
+  });
+
+  it('trigger has aria-expanded false when closed', () => {
+    render(<SourceDropdown sources={[FULL_SOURCE]} />);
+    const trigger = screen.getByRole('button', { name: /source/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens the dropdown panel on click', () => {
+    render(<SourceDropdown sources={[FULL_SOURCE]} />);
+    const trigger = screen.getByRole('button', { name: /source/i });
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('renders source name as link when url is present', () => {
+    render(<SourceDropdown sources={[FULL_SOURCE]} />);
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+
+    const link = screen.getByRole('link', { name: 'The Lodestone' });
+    expect(link).toHaveAttribute('href', 'https://lodestone.example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders source name as plain text when url is absent', () => {
+    render(<SourceDropdown sources={[MINIMAL_SOURCE]} />);
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+
+    expect(screen.getByText('XIVAPI')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'XIVAPI' })).not.toBeInTheDocument();
+  });
+
+  it('renders patch/date metadata when present', () => {
+    render(<SourceDropdown sources={[FULL_SOURCE]} />);
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+
+    expect(screen.getByText('Last updated: Patch 7.1')).toBeInTheDocument();
+  });
+
+  it('does not render metadata line when patch/date is absent', () => {
+    render(<SourceDropdown sources={[MINIMAL_SOURCE]} />);
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+
+    expect(screen.queryByText(/last updated/i)).not.toBeInTheDocument();
+  });
+
+  it('closes the dropdown on second click (toggle)', () => {
+    render(<SourceDropdown sources={[FULL_SOURCE]} />);
+    const trigger = screen.getByRole('button', { name: /source/i });
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes the dropdown on Escape key', () => {
+    render(<SourceDropdown sources={[FULL_SOURCE]} />);
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes the dropdown on click outside', () => {
+    render(
+      <div>
+        <SourceDropdown sources={[FULL_SOURCE]} />
+        <button type="button">Outside</button>
+      </div>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Outside' }));
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('renders multiple sources in the panel', () => {
+    render(<SourceDropdown sources={[FULL_SOURCE, MINIMAL_SOURCE]} />);
+    fireEvent.click(screen.getByRole('button', { name: /source/i }));
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(2);
+  });
+});

--- a/frontend/tests/hooks/useChatConversation.test.tsx
+++ b/frontend/tests/hooks/useChatConversation.test.tsx
@@ -5,7 +5,7 @@ import { CHAT_THREAD_GREETING } from '@/features/chat/chatThreadGreeting';
 import type { ChatAssistantPort } from '@/lib/chat/chatAssistantPort';
 import { DEMO_ASSISTANT_REPLY } from '@/lib/chat/chatAssistantPort';
 import { ChatSessionLanding } from '@/types/chatSession';
-import { MessageRole } from '@/types/chat';
+import { ConversationRole } from '@chatxiv/cdm';
 import { logger } from '@/lib/logger/instance';
 
 describe('useChatConversation', () => {
@@ -20,7 +20,7 @@ describe('useChatConversation', () => {
       result.current.sendMessage('hi');
     });
     expect(result.current.messages).toHaveLength(1);
-    expect(result.current.messages[0]?.role).toBe(MessageRole.User);
+    expect(result.current.messages[0]?.role).toBe(ConversationRole.User);
 
     await waitFor(
       () => {
@@ -72,7 +72,7 @@ describe('useChatConversation', () => {
 
     rerender({ gen: 1, landing: ChatSessionLanding.Thread });
     expect(result.current.messages).toHaveLength(1);
-    expect(result.current.messages[0]?.role).toBe(MessageRole.Assistant);
+    expect(result.current.messages[0]?.role).toBe(ConversationRole.Assistant);
     expect(result.current.messages[0]?.text).toBe(CHAT_THREAD_GREETING);
 
     rerender({ gen: 2, landing: ChatSessionLanding.Welcome });

--- a/frontend/tests/hooks/useSourceMeta.test.ts
+++ b/frontend/tests/hooks/useSourceMeta.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSourceMeta } from '@/hooks/useSourceMeta';
+import type { SourceCitation } from '@chatxiv/cdm';
+
+describe('useSourceMeta', () => {
+  it('returns empty array when sources is undefined', () => {
+    const { result } = renderHook(() => useSourceMeta(undefined));
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns empty array when sources is empty', () => {
+    const { result } = renderHook(() => useSourceMeta([]));
+    expect(result.current).toEqual([]);
+  });
+
+  it('maps sourceName to label and sourceUrl to url', () => {
+    const sources: SourceCitation[] = [
+      { sourceName: 'Wiki', sourceUrl: 'https://wiki.example.com' },
+    ];
+    const { result } = renderHook(() => useSourceMeta(sources));
+    expect(result.current).toEqual([
+      { label: 'Wiki', url: 'https://wiki.example.com', patchOrDate: undefined },
+    ]);
+  });
+
+  it('prefers patchOrDate over lastUpdated', () => {
+    const sources: SourceCitation[] = [
+      { sourceName: 'Guide', patchOrDate: 'Patch 7.1', lastUpdated: '2025-01-01' },
+    ];
+    const { result } = renderHook(() => useSourceMeta(sources));
+    expect(result.current[0]?.patchOrDate).toBe('Patch 7.1');
+  });
+
+  it('falls back to lastUpdated when patchOrDate is absent', () => {
+    const sources: SourceCitation[] = [{ sourceName: 'API', lastUpdated: '2025-06-15' }];
+    const { result } = renderHook(() => useSourceMeta(sources));
+    expect(result.current[0]?.patchOrDate).toBe('2025-06-15');
+  });
+
+  it('handles minimal sources with only sourceName', () => {
+    const sources: SourceCitation[] = [{ sourceName: 'XIVAPI' }];
+    const { result } = renderHook(() => useSourceMeta(sources));
+    expect(result.current).toEqual([{ label: 'XIVAPI', url: undefined, patchOrDate: undefined }]);
+  });
+
+  it('maps multiple sources correctly', () => {
+    const sources: SourceCitation[] = [
+      {
+        sourceName: 'Lodestone',
+        sourceUrl: 'https://lodestone.example.com',
+        patchOrDate: 'Patch 7.0',
+      },
+      { sourceName: 'XIVAPI' },
+      { sourceName: 'The Balance', lastUpdated: '2025-03-10' },
+    ];
+    const { result } = renderHook(() => useSourceMeta(sources));
+    expect(result.current).toHaveLength(3);
+    expect(result.current[0]?.label).toBe('Lodestone');
+    expect(result.current[1]?.url).toBeUndefined();
+    expect(result.current[2]?.patchOrDate).toBe('2025-03-10');
+  });
+});

--- a/frontend/tests/lib/chat/chatAssistantPort.test.ts
+++ b/frontend/tests/lib/chat/chatAssistantPort.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createDemoChatAssistantPort, DEMO_ASSISTANT_REPLY } from '@/lib/chat/chatAssistantPort';
+import {
+  createDemoChatAssistantPort,
+  DEMO_ASSISTANT_REPLY,
+  DEMO_ASSISTANT_SOURCES,
+} from '@/lib/chat/chatAssistantPort';
 
 describe('createDemoChatAssistantPort', () => {
   beforeEach(() => {
@@ -10,11 +14,14 @@ describe('createDemoChatAssistantPort', () => {
     vi.useRealTimers();
   });
 
-  it('resolves with the demo reply after the delay', async () => {
+  it('resolves with the demo reply and sources after the delay', async () => {
     const port = createDemoChatAssistantPort(500);
     const p = port.getReply('hello');
     await vi.advanceTimersByTimeAsync(500);
-    await expect(p).resolves.toEqual({ text: DEMO_ASSISTANT_REPLY });
+    await expect(p).resolves.toEqual({
+      text: DEMO_ASSISTANT_REPLY,
+      sources: DEMO_ASSISTANT_SOURCES,
+    });
   });
 
   it('rejects with AbortError when the signal is aborted before the delay', async () => {


### PR DESCRIPTION
## Overview
Adds a chat source dropdown, `useSourceMeta`, and wires source metadata through conversation, assistant port, and message list; updates styles/tests.

---
## Revision 1

- New `SourceDropdown` UI and `useSourceMeta` hook
- Chat conversation / message list integration and assistant port typing
- Tests and layout/CSS tweaks for message list / feedback bar

---
## Testing
- [x] Tests pass locally (`npm run test:coverage`)
- [x] Lint and format check pass
- [x] CI passes on GitHub
### With Sources
<img width="1912" height="494" alt="image" src="https://github.com/user-attachments/assets/fe3ae9b5-97b8-4757-8fe4-c6f487072bb0" />
### Without Sources
<img width="1187" height="242" alt="image" src="https://github.com/user-attachments/assets/bc483485-8b13-463b-91cf-ba09bb978205" />
